### PR TITLE
Better histogram

### DIFF
--- a/comport/static/js/chartConfigs.js
+++ b/comport/static/js/chartConfigs.js
@@ -229,6 +229,7 @@ var configs = {
     xFunc: function(b){ return b[0].allegation; },
     y: 'count',
     yFunc: function(b){ return b.length; },
+    dataMapAdjust: addOtherCategory,
     },
 
 
@@ -241,6 +242,7 @@ var configs = {
     xFunc: function(b){ return b[0].allegationType; },
     y: 'count',
     yFunc: function(b){ return b.length; },
+    dataMapAdjust: addOtherCategory,
     },
 
   'complaints-by-precinct': {
@@ -281,7 +283,7 @@ var configs = {
 
 };
 
-
+// Running the all the code that draws the charts
 d3.csv(
   csv_url,
   function(error, rows){

--- a/comport/static/js/charts.js
+++ b/comport/static/js/charts.js
@@ -162,6 +162,34 @@ function raceMatrix(config, data){
   return counts;
 }
 
+function addOtherCategory(dataMap){
+  var threshold = .01;
+  var small_list = [];
+  var total = dataMap.values().map(function (g){
+    return g.count;
+  }).reduce(function (a,b) {
+    return a + b;
+  }); 
+  var otherTotal = 0;
+
+  dataMap.forEach(function(key, group) {
+    if(group.count / total < threshold){
+      small_list.push(key);
+      otherTotal = otherTotal + group.count;
+    }
+  });
+    
+  dataMap.set("Other", {
+    count: otherTotal,
+    type: "Other",
+    groups: small_list,
+  });
+  
+  small_list.forEach(function(key){
+    dataMap.remove(key);
+  });
+}
+
 function officerComplaintsCount(config, data){
   data = uniqueOfficerComplaints(data);
   var counts = d3.nest()
@@ -325,6 +353,5 @@ drawFuncs = {
   'map': mapChart,
   'percent': basicPercent,
   'flagHistogram': flagHistogram,
-  'mountainHistogram': mountainHistogram,
   'matrix': matrixChart,
 }

--- a/comport/static/js/histogram.js
+++ b/comport/static/js/histogram.js
@@ -56,8 +56,6 @@ function flagHistogram(config, data){
   // set basic dimensions
   // we need a width, a height for each
   var width,
-      margin,
-      barHeight,
       font_size;
 
   font_size = 14; // px
@@ -72,7 +70,7 @@ function flagHistogram(config, data){
 
   var y = function(d){ return yScale(d[config.y]) };
 
-  // draw table
+  // draw containing table node
   var table = d3.select(config.parent)
     .append("table")
     .attr("class", "flagHistogram-table");
@@ -83,6 +81,11 @@ function flagHistogram(config, data){
 
   var rowLabels = rows.append("td")
     .attr("class", "hist-label")
+    .attr("title", function(d){
+      if( d[config.x] == "Other" ){
+        return "Other includes:\n- " + d.groups.join("\n- ");
+      }
+    })
     .text(function(d){ return d[config.x] || "Unspecified"; });
 
   var flags = rows.append("td")


### PR DESCRIPTION
Works on adding an "Other" category to histograms. This makes a threshold %, and rows with counts that fall below the designated threshold percent of the total count are lumped into the "Other" category. "Other" can be moused over to show the categories that it ate.

Nice work @TiffanyAndrews!
