### PR TITLE
Add date spans

### DIFF
--- a/comport/static/css/charts.css
+++ b/comport/static/css/charts.css
@@ -1,3 +1,5 @@
+
+
 .chart {
   font-size: 0.8em;
   line-height: 1.1em;
@@ -29,12 +31,12 @@
 .sym-flag-table tr + tr {
   border-top: 1px solid #eee;
 }
-.sym-flag-table td, .sym-flag-table th { 
+.sym-flag-table td, .sym-flag-table th {
   padding: 0.3em 0 0.3em 0;
 }
 
-th.sym-flag-col-header { 
-  text-align: center; 
+th.sym-flag-col-header {
+  text-align: center;
   font-weight: 300;
   text-transform: uppercase;
   letter-spacing: 1px;

--- a/comport/static/css/style.css
+++ b/comport/static/css/style.css
@@ -105,10 +105,20 @@ textarea {
   margin-top: 2em;
 }
 
-.brick-title {
+.brick-titleblock {
   border-bottom: 1px solid black;
   padding-bottom: 0.6em;
   margin-bottom: 1em;
+}
+.brick-datespan {
+  font-family: "Source Sans Pro", sans-serif;
+  font-size: 0.9em;
+  font-weight: normal;
+  margin-left: 1em;
+}
+.brick-datespan .month {
+  text-transform: uppercase;
+  font-size: 0.9em;
 }
 
 /*Schema */

--- a/comport/static/css/style.css
+++ b/comport/static/css/style.css
@@ -110,14 +110,14 @@ textarea {
   padding-bottom: 0.6em;
   margin-bottom: 1em;
 }
+span.brick-title {
+  margin-right: 1em;
+}
 .brick-datespan {
-  font-family: "Source Sans Pro", sans-serif;
   font-size: 0.9em;
   font-weight: normal;
-  margin-left: 1em;
 }
 .brick-datespan .month {
-  text-transform: uppercase;
   font-size: 0.9em;
 }
 

--- a/comport/static/js/chartConfigs.js
+++ b/comport/static/js/chartConfigs.js
@@ -64,8 +64,8 @@ var configs = {
 
   'uof-map': {
     chartType: 'map',
-    filter: function(b){
-      return last12Months(b).filter(function(d){
+    filter: function(b, config){
+      return last12Months(b, config).filter(function(d){
        if( d.censusTract ){ return true; } else { return false; }
       });
     },
@@ -168,6 +168,7 @@ var configs = {
     },
 
   'officer-demographics': {
+    hideDate: true,
     chartType: 'symmetricalFlags',
     dataFunc: function(){ return DEMOGRAPHICS; }
     },
@@ -197,8 +198,8 @@ var configs = {
 
   'complaints-by-year': {
     chartType: 'lineChart',
-    filter: function(rows){
-      return allegationsToComplaints(rows);
+    filter: function(rows, config){
+      return allegationsToComplaints(rows, config);
     },
     keyFunc: function(d){ return d.date.getFullYear(); },
     dataMapAdjust: addMissingYears,
@@ -213,8 +214,8 @@ var configs = {
 
   'complaints-by-month': {
     chartType: 'lineChart',
-    filter: function(rows){
-      return allegationsToComplaints(last12Months(rows));
+    filter: function(rows, config){
+      return allegationsToComplaints(last12Months(rows, config), config);
     },
     keyFunc: function(d){ return d3.time.format('%Y %m')(d.date); },
     sortWith: function(d){ return d.month; },
@@ -334,7 +335,9 @@ d3.csv(
   function(error, rows){
     // parse the raw csv data
     var parsed_rows = parseData(rows);
+
     allRows = rows;
+    allRows.dateSpan = d3.extent(rows, function(d){ return d.date; });
 
     // deal with each chart configuration
     charts.forEach(function(name){
@@ -345,6 +348,7 @@ d3.csv(
       if( config.chartType ){
         // get class name for parent div
         config.parent = '.' + name;
+        config.brick = '#' + name;
         drawChart(parsed_rows, config);
       }
 

--- a/comport/static/js/charts.js
+++ b/comport/static/js/charts.js
@@ -1,13 +1,5 @@
 var allRows;
 
-function last12Months(rows){
-  // offset today by 12 d3-defined months in the past
-  var latestDate = d3.max(rows, function(d){ return d.date; })
-  var startDate = d3.time.month.offset(latestDate, -12);
-  return rows.filter(function(r){
-    return startDate < r.date;
-  });
-}
 
 function notEqual(a, b){
   if( a instanceof Date || b instanceof Date ){
@@ -198,8 +190,6 @@ function officerComplaintsCount(config, data){
     obj[config.y] = e.values;
     return obj;
   });
-
-
 }
 
 var experienceBuckets = d3.scale.quantize()
@@ -230,49 +220,6 @@ function nullify(value){
   } else {
     return value
   }
-}
-
-var dateTimeFormat = d3.time.format("%Y-%m-%d %H:%M:%S");
-var dateTimeKey = "occuredDate";
-
-function parseDate(dateTimeString){
-  return dateTimeString ? dateTimeFormat.parse(dateTimeString) : null;
-}
-
-function parseData(rows){
-  // parses dates and nulls from the raw csv
-  rows.forEach(function(r){
-    var dateString = nullify(r[dateTimeKey]);
-    r.date = parseDate(dateString);
-  });
-  rows = rows.filter(function(d){
-    return d.date;
-  });
-  return rows;
-}
-
-function drawChart(rows, config){
-  // structure data for the particular chart
-  if( config.dataFunc ){
-    var data = config.dataFunc(config, rows);
-  } else {
-    var data = structureData(rows, config);
-  }
-
-  // get the correct function for drawing this chart
-  drawingFunction = drawFuncs[config.chartType];
-
-  // if we have no chart block in the database, just make the brick
-  if(config.noTemplate){
-    var brick = d3.select('[role=main]')
-      .append('div').attr("class", "brick");
-    brick.append("h4").attr("class", "brick-title")
-      .text(config.title);
-    config.parent = brick.append("div").attr("class", config.parent)[0][0];
-  }
-
-  // run the function to draw the chart
-  drawingFunction(config, data);
 }
 
 function addMissingYears(dataMap){
@@ -322,17 +269,39 @@ function addOtherCategory(data){
     data.splice(i, 1);
     removed_count += 1;
   });
-
 }
 
+function last12Months(rows, config){
+  // offset today by 12 d3-defined months in the past
+  var latestDate = d3.max(rows, function(d){ return d.date; })
+  var startDate = d3.time.month.offset(latestDate, -12);
+  config.dateSpan = [startDate, latestDate];
+  return rows.filter(function(r){
+    return startDate < r.date;
+  });
+}
+
+var dateTimeFormat = d3.time.format("%Y-%m-%d %H:%M:%S");
+var niceMonthYearFormat = d3.time.format('<span class="month">%b</span> <span class="year">%Y</span>');
+var dateTimeKey = "occuredDate";
+function parseDate(dateTimeString){
+  return dateTimeString ? dateTimeFormat.parse(dateTimeString) : null;
+}
+
+function parseData(rows){
+  // parses dates and nulls from the raw csv
+  rows.forEach(function(r){
+    var dateString = nullify(r[dateTimeKey]);
+    r.date = parseDate(dateString);
+  });
+  rows = rows.filter(function(d){
+    return d.date;
+  });
+  return rows;
+}
 
 function structureData(parsed_rows, config){
   // restructures csv data into data than can be used to draw a chart
-
-  // filter rows if necessary
-  if( config.filter ){
-    parsed_rows = config.filter(parsed_rows);
-  }
 
   // create a grouping machine that groups by key function
   var data_grouper = d3.nest()
@@ -378,6 +347,54 @@ function structureData(parsed_rows, config){
     addOtherCategory(structured_data)
   }
   return structured_data;
+}
+
+function drawChart(rows, config){
+
+  // filter rows if necessary
+  if( config.filter ){
+    rows = config.filter(rows, config);
+  }
+
+  // structure data for the particular chart
+  if( config.dataFunc ){
+    var data = config.dataFunc(config, rows);
+  } else {
+    var data = structureData(rows, config);
+  }
+  if( !config.dateSpan ){
+    config.dateSpan = allRows.dateSpan;
+  }
+
+  if( !config.hideDate ){
+    // add the date interval for this chart's data
+    $(config.brick).find('.brick-title').append(
+      ' <span class="brick-datespan">' +
+        '<span class="brick-datespan-start">' +
+          niceMonthYearFormat(config.dateSpan[0]) +
+        '</span> ' +
+        '<span class="brick-datespan-separator">' +
+          '—' +
+        '</span> ' +
+        '<span class="brick-datespan-end">' +
+          niceMonthYearFormat(config.dateSpan[1]) +
+        '</span>' +
+      '</span>');
+  }
+  // get the correct function for drawing this chart
+  drawingFunction = drawFuncs[config.chartType];
+
+  // if we have no chart block in the database, just make the brick
+  if(config.noTemplate){
+    var brick = d3.select('[role=main]')
+      .append('div').attr("class", "brick");
+    brick.append("h4").attr("class", "brick-title")
+      .text(config.title);
+    config.parent = brick.append("div").attr("class", config.parent)[0][0];
+  }
+
+  // run the function to draw the chart
+  drawingFunction(config, data);
 }
 
 drawFuncs = {

--- a/comport/static/js/charts.js
+++ b/comport/static/js/charts.js
@@ -282,7 +282,7 @@ function last12Months(rows, config){
 }
 
 var dateTimeFormat = d3.time.format("%Y-%m-%d %H:%M:%S");
-var niceMonthYearFormat = d3.time.format('<span class="month">%b</span> <span class="year">%Y</span>');
+var niceMonthYearFormat = d3.time.format('<span class="month">%b</span>&nbsp;<span class="year">%Y</span>');
 var dateTimeKey = "occuredDate";
 function parseDate(dateTimeString){
   return dateTimeString ? dateTimeFormat.parse(dateTimeString) : null;
@@ -368,14 +368,14 @@ function drawChart(rows, config){
 
   if( !config.hideDate ){
     // add the date interval for this chart's data
-    $(config.brick).find('.brick-title').append(
+    $(config.brick).find('.brick-titleblock > h4').append(
       ' <span class="brick-datespan">' +
         '<span class="brick-datespan-start">' +
           niceMonthYearFormat(config.dateSpan[0]) +
-        '</span> ' +
+        '</span>&nbsp;' +
         '<span class="brick-datespan-separator">' +
           '—' +
-        '</span> ' +
+        '</span>&nbsp;' +
         '<span class="brick-datespan-end">' +
           niceMonthYearFormat(config.dateSpan[1]) +
         '</span>' +

--- a/comport/templates/department/site/chart_block.html
+++ b/comport/templates/department/site/chart_block.html
@@ -30,7 +30,9 @@
          </br>
       {% else %}
         <div class="brick-titleblock col-md-12">
-          <h4 class="brick-title">{{ chart_block.title }}</h4>
+          <h4>
+            <span class="brick-title">{{ chart_block.title }}</span>
+          </h4>
         </div>
         <div class="col-md-6">
           <div class="chart {{ chart_block.slug }}"></div>

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 # Testing
 pytest>=2.6.3
 webtest
-requests
+requests==2.9.1
 
 # Management script
 Flask-Script


### PR DESCRIPTION
This PR adds date spans to each chart (_except department demographics_) like so:

![screen shot 2016-01-13 at 5 15 31 pm](https://cloud.githubusercontent.com/assets/451510/12313071/5aa1be44-ba19-11e5-8d57-2f70cc29976c.png)

The date span uses non-breaking spaces, `&nbsp;` so that it moves to the next line when the titleblock width is constrained:

![screen shot 2016-01-13 at 5 16 01 pm](https://cloud.githubusercontent.com/assets/451510/12313072/5aa30060-ba19-11e5-80c2-c3344ecd2a2b.png)