### PR TITLE
putting first chart above the fold

### DIFF
--- a/comport/static/css/charts.css
+++ b/comport/static/css/charts.css
@@ -64,7 +64,7 @@ td span + span {
 }
 
 .hist-label {
-  max-width: 10em;
+  max-width: 9em;
 }
 .hist-flag-bar {
   height: 1em;

--- a/comport/static/css/charts.css
+++ b/comport/static/css/charts.css
@@ -46,7 +46,7 @@ th.sym-flag-col-header {
 .sym-flag-row-label { width: 15%; text-align: right; }
 
 td span + span {
-  margin-left: 1em;
+  margin-left: 0.5em;
 }
 
 
@@ -63,7 +63,7 @@ td span + span {
 }
 
 .hist-label {
-  max-width: 18em;
+  max-width: 13em;
 }
 .hist-flag-bar {
   height: 1em;
@@ -84,6 +84,33 @@ td span + span {
   border-top: 1px solid #eee;
 }
 
+
+/* mountainHistogram */
+.mountainHistogram-table {
+  text-align: center;
+}
+
+.hist-flag-vert-bar {
+  width: 1.2em;
+  background-color: #205493;
+  display: inline-block;
+}
+
+.hist-flag-vert {
+  vertical-align: bottom;
+}
+td.hist-flag-vert-label-month {
+  padding: 0.25em 0.14em .5em 0.14em;
+}
+td.hist-label-year {
+  padding-top: 0.5em;
+  border-top: 1px solid #aaa;
+}
+td.hist-label-year + td.hist-label-year {
+  border-left: 1px solid #aaa;
+}
+
+/* percents */
 .percent + .percent { margin-left: 2em; }
 .percent-amt { font-size: 2em; }
 .percent-symbol { font-size: 0.6em; }

--- a/comport/static/css/charts.css
+++ b/comport/static/css/charts.css
@@ -4,7 +4,8 @@
   font-size: 0.8em;
   line-height: 1.1em;
   font-family: "Source Sans Pro", sans-serif;
-  overflow: auto;
+  overflow-x: scroll;
+  overflow-y: hidden;
 }
 
 .trend-line {
@@ -28,7 +29,8 @@
   stroke: #aaa;
 }
 
-.sym-flag-table { width: 100%; }
+.sym-flag-table, .mountainHistogram-table, .flagHistogram-table { width: 100%; }
+
 .sym-flag-table tr + tr {
   border-top: 1px solid #eee;
 }
@@ -63,9 +65,13 @@ td span + span {
   display: inline-block;
 }
 
-.hist-label {
-  max-width: 9em;
+td.hist-label {
+  width: 50%;
 }
+td.hist-flag {
+  width: 50%;
+}
+
 .hist-flag-bar {
   height: 1em;
   background-color: #205493;
@@ -92,7 +98,7 @@ td span + span {
 }
 
 .hist-flag-vert-bar {
-  width: 1.2em;
+  width: 1em;
   background-color: #205493;
   display: inline-block;
 }
@@ -100,8 +106,15 @@ td span + span {
 .hist-flag-vert {
   vertical-align: bottom;
 }
+.hist-flag-vert > span {
+  display: inline-block;
+}
+span.hist-flag-vert-label {
+  margin-bottom: .3em;
+}
 td.hist-flag-vert-label-month {
-  padding: 0.25em 0.14em .5em 0.14em;
+  padding-top: 0.25em;
+  padding-bottom: .5em;
 }
 td.hist-label-year {
   padding-top: 0.5em;

--- a/comport/static/css/charts.css
+++ b/comport/static/css/charts.css
@@ -4,6 +4,7 @@
   font-size: 0.8em;
   line-height: 1.1em;
   font-family: "Source Sans Pro", sans-serif;
+  overflow: auto;
 }
 
 .trend-line {
@@ -63,7 +64,7 @@ td span + span {
 }
 
 .hist-label {
-  max-width: 13em;
+  max-width: 10em;
 }
 .hist-flag-bar {
   height: 1em;

--- a/comport/static/css/style.css
+++ b/comport/static/css/style.css
@@ -95,16 +95,14 @@ textarea {
   resize: vertical;
 }
 
-.container-narrow{
+.container-narrow {
   margin: 0 auto;
   max-width: 700px;
 }
 
-/* Bricks/Blocks */
-.row + .row {
-  margin-top: 2em;
-}
+.brick { padding-top: 3em; }
 
+.brick .chart, .brick .content { margin-top: 1.5em; }
 .brick-titleblock {
   border-bottom: 1px solid black;
   padding-bottom: 0.6em;

--- a/comport/static/js/chartConfigs.js
+++ b/comport/static/js/chartConfigs.js
@@ -213,7 +213,7 @@ var configs = {
     },
 
   'complaints-by-month': {
-    chartType: 'lineChart',
+    chartType: 'mountainHistogram',
     filter: function(rows, config){
       return allegationsToComplaints(last12Months(rows, config), config);
     },

--- a/comport/static/js/charts.js
+++ b/comport/static/js/charts.js
@@ -401,6 +401,7 @@ drawFuncs = {
   'lineChart': lineChart,
   'percent': basicPercent,
   'flagHistogram': flagHistogram,
+  'mountainHistogram': mountainHistogram,
   'symmetricalFlags': symmetricalFlags,
   'matrix': matrixChart,
 }

--- a/comport/static/js/histogram.js
+++ b/comport/static/js/histogram.js
@@ -58,6 +58,71 @@ function basicPercent(config, data){
 
 }
 
+function mountainHistogram(config, data){
+  // a histogram with vertical bars and a horizontal axis
+  var height = 5,
+      font_size = 14;
+  var yScale = d3.scale.linear()
+    .domain([0,
+      d3.max(data, function(d){ return d[config.y]})
+      ])
+    .range([0, font_size * height]);
+
+  var y = function(d){ return yScale(d[config.y]); };
+
+  var table = d3.select(config.parent)
+    .append("table")
+    .attr("class", "mountainHistogram-table");
+
+  var flagCells = table.append("tr")
+    .selectAll("td.hist-flag-vert")
+    .data(data).enter()
+    .append("td")
+    .attr("class", "hist-flag-vert");
+
+  var flagLabels = flagCells.append("span")
+    .attr("class", "hist-flag-vert-label")
+    .text(function(d){return d[config.y];});
+
+  flagCells.append("br");
+
+  var flagBars = flagCells.append("span")
+    .attr("class", "hist-flag-vert-bar")
+    .style("height", function (d){ return y(d) + "px"; })
+
+  var monthFormat = d3.time.format("%b");
+  var yearFormat = d3.time.format("%Y");
+  var monthCells = table.append("tr")
+    .selectAll("td.hist-label-month")
+    .data(data).enter()
+    .append("td")
+    .attr("class", "hist-flag-vert-label-month")
+    .text(function(d){
+      return monthFormat(d[config.x]);
+    });
+
+  var years =d3.nest()
+    .key(function(d){ return d; })
+    .rollup(function(yrs){
+      return {
+        year: yrs[0],
+        count: yrs.length
+      }
+    }).map(data.map(function(d){
+      return yearFormat(d[config.x]);
+    }), d3.map).values();
+
+  var yearCells = table.append("tr")
+    .selectAll("td.hist-label-year")
+    .data(years).enter()
+    .append("td")
+    .attr("class", "hist-label-year")
+    .attr("colspan", function(d){ return d.count; })
+    .text(function(d){ return d.year });
+
+
+}
+
 function flagHistogram(config, data){
 
   // set basic dimensions
@@ -66,7 +131,7 @@ function flagHistogram(config, data){
       font_size;
 
   font_size = 14; // px
-  width = 12;
+  width = 9;
 
   // set y axis scale
   var yScale = d3.scale.linear()

--- a/comport/static/js/histogram.js
+++ b/comport/static/js/histogram.js
@@ -131,7 +131,7 @@ function flagHistogram(config, data){
       font_size;
 
   font_size = 14; // px
-  width = 9;
+  width = 8;
 
   // set y axis scale
   var yScale = d3.scale.linear()

--- a/comport/static/js/histogram.js
+++ b/comport/static/js/histogram.js
@@ -127,20 +127,15 @@ function flagHistogram(config, data){
 
   // set basic dimensions
   // we need a width, a height for each
-  var width,
-      font_size;
-
-  font_size = 14; // px
-  width = 8;
 
   // set y axis scale
   var yScale = d3.scale.linear()
     .domain([ 0,
         d3.max(data, function(d){ return d[config.y]; })
         ])
-    .range([0, font_size * width]);
+    .range([0, 70]);
 
-  var y = function(d){ return yScale(d[config.y]) };
+  var y = function(d){ return yScale(d[config.y]) + "%" };
 
   // draw containing table node
   var table = d3.select(config.parent)
@@ -174,7 +169,7 @@ function flagHistogram(config, data){
 
   var flagBars = flags.append("span")
     .attr("class", "hist-flag-bar")
-    .style("width", function (d){ return y(d) + "px"; });
+    .style("width", function (d){ return y(d); });
 
   var flagLabels = flags.append("span")
     .attr("class", "hist-flag-label")

--- a/comport/templates/department/site/chart_block.html
+++ b/comport/templates/department/site/chart_block.html
@@ -1,5 +1,4 @@
 {% macro chart_toc(blocks) %}
-
 <h3>Table of Contents</h3>
 <ul class="blocks">
   {% for block in blocks %}
@@ -8,39 +7,35 @@
   </li>
   {% endfor %}
 </ul>
-
 {% endmacro %}
 
-{% macro brick(chart_block, department, editing=False) %}
-<div class="row" id="{{ chart_block.slug }}">
-    <div class="brick">
-      {% if editing %}
-          <form method="post" action="/content/{{chart_block.slug}}/{{department.id}}">
-            <div class="form-group">
-              <label for="chart_title">Chart Title:</label>
-              <input type="text" class="form-control" name="chart_title" value="{{chart_block.title}}"/><br />
-            </div>
-              <div class="chart {{ chart_block.slug }}"></div>
-            <div class="form-group">
-              <label for="chart_content">Content:</label>
-              <textarea class="form-control" name="chart_content">{{ chart_block.content }}</textarea>
-            </div>
-              <input type="submit" />
-           </form>
-         </br>
-      {% else %}
-        <div class="brick-titleblock col-md-12">
+{% macro brick(chart_block, department, editing=False, one_col=False) %}
+  <div id="{{ chart_block.slug }}" class="brick col-xs-12 {% if one_col %}col-sm-7{% else %}col-sm-12{% endif %}">
+    {% if editing %}
+        <form method="post" action="/content/{{chart_block.slug}}/{{department.id}}">
+          <div class="form-group">
+            <label for="chart_title">Chart Title:</label>
+            <input type="text" class="form-control" name="chart_title" value="{{chart_block.title}}"/><br />
+          </div>
+            <div class="chart {{ chart_block.slug }}"></div>
+          <div class="form-group">
+            <label for="chart_content">Content:</label>
+            <textarea class="form-control" name="chart_content">{{ chart_block.content }}</textarea>
+          </div>
+            <input type="submit" />
+         </form>
+       </br>
+    {% else %}
+      <div class="brick-titleblock">
           <h4>
             <span class="brick-title">{{ chart_block.title }}</span>
           </h4>
         </div>
-        <div class="col-md-6">
-          <div class="chart {{ chart_block.slug }}"></div>
-        </div>
-        <div class="col-md-5">
-          <div class="content">{{ markdown(chart_block.content) }}</div>
-        </div>
-      {% endif %}
-  </div>
+
+      <div class="row">
+        <div class="chart {{ chart_block.slug }}{% if not one_col %} col-sm-6{% else %} col-sm-12{% endif %}"></div>
+        <div class="content{% if not one_col %} col-sm-5{% else %} col-sm-10{% endif %}">{{ markdown(chart_block.content) }}</div>
+      </div>
+    {% endif %}
 </div>
 {% endmacro %}

--- a/comport/templates/department/site/complaints.html
+++ b/comport/templates/department/site/complaints.html
@@ -7,6 +7,11 @@
 
     <h2>Citizen Complaints</h2>
 
+    <p class="intro_text">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
+    </p>
+
     <!-- data button -->
     <a href="{{ url_for(
       'department.public_complaints_schema', short_name=department.short_name.upper())
@@ -30,17 +35,17 @@
       <input type="submit" />
     </form>
   </div>  <!-- end col -->
-  {% else %}
-  <div id="{{ chart_blocks[0].slug }}" class="intro-text col-xs-11 col-sm-7 col-md-6 col-lg-5">
-    {{ markdown(chart_blocks[0].content) }}
-  </div>  <!-- end col -->
   {% endif %}
+
+{{ brick(chart_blocks[1], department, editing, one_col=True) }}
 
 </div>  <!-- end row -->
 
 {% for block in chart_blocks %}
-{%- if "-introduction" not in block.slug %}
+{%- if "-introduction" not in block.slug and '-by-month' not in block.slug %}
+<div class="row">
 {{ brick(block, department, editing) }}
+</div>
 {%- endif %}
 {%- endfor %}
 

--- a/comport/templates/department/site/dataset_nav.html
+++ b/comport/templates/department/site/dataset_nav.html
@@ -1,7 +1,7 @@
 
 <div class="row">
 
-    <ul class="nav nav-tabs nav-justified dataset_nav" role="navigation">
+    <ul class="nav nav-tabs nav-justified dataset_nav col-xs-12" role="navigation">
       <li class="{% if url_for(
             'department.public_complaints', short_name=department.short_name.upper()
             ) == request.path

--- a/comport/templates/department/site/ois.html
+++ b/comport/templates/department/site/ois.html
@@ -4,7 +4,7 @@
 
 <div class="row">
 
-  <div class="col-lg-6">
+  <div class="col-xs-12 col-sm-5">
     <h2>Officer Inolved Shootings</h2>
 
     <p class="intro_text">

--- a/comport/templates/department/site/ois.html
+++ b/comport/templates/department/site/ois.html
@@ -6,6 +6,13 @@
 
   <div class="col-lg-6">
     <h2>Officer Inolved Shootings</h2>
+
+    <p class="intro_text">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
+    </p>
+
+    <!-- data button -->
     <a href="{{ url_for(
       'department.public_ois_schema', short_name=department.short_name.upper())
       }}" class="btn btn-primary btn-lg">
@@ -29,19 +36,17 @@
         <input type="submit" />
      </form>
   </div>  <!-- end col -->
-
-  {% else %}
-
-  <div id="{{ chart_blocks[0].slug }}" class="intro-text col-sm-5">
-    {{ markdown(chart_blocks[0].content) }}
-  </div>  <!-- end col -->
   {% endif %}
+
+{{ brick(chart_blocks[1], department, editing, one_col=True) }}
 
 </div>  <!-- end row -->
 
 {% for block in chart_blocks %}
-{%- if "-introduction" not in block.slug %}
+{%- if "-introduction" not in block.slug and '-by-month' not in block.slug %}
+<div class="row">
 {{ brick(block, department, editing) }}
+</div>
 {%- endif %}
 {%- endfor %}
 

--- a/comport/templates/department/site/useofforce.html
+++ b/comport/templates/department/site/useofforce.html
@@ -4,7 +4,7 @@
 
 <div class="row">
 
-  <div class="col-lg-6">
+  <div class="col-xs-12 col-sm-5">
     <h2>Use of Force</h2>
     <a href="{{ url_for(
       'department.public_uof_schema', short_name=department.short_name.upper())
@@ -19,7 +19,7 @@
 
 
   {% if editing %}
-  <div class="editing-form col-lg-6">
+  <div class="editing-form col-xs-12 col-lg-6">
     <form method="post" action="/content/uof-introduction/{{department.id}}">
       <div class="form-group">
         <label for="chart_content">Content:</label>

--- a/comport/templates/department/site/useofforce.html
+++ b/comport/templates/department/site/useofforce.html
@@ -29,20 +29,18 @@
         <input type="submit" />
      </form>
   </div>  <!-- end col -->
-
-  {% else %}
-
-  <div id="{{ chart_blocks[0].slug }}" class="intro-text col-lg-5">
-    {{ markdown(chart_blocks[0].content) }}
-  </div>  <!-- end col -->
   {% endif %}
+
+{{ brick(chart_blocks[1], department, editing, one_col=True) }}
 
 </div>  <!-- end row -->
 
 
 {% for block in chart_blocks %}
-{%- if "-introduction" not in block.slug %}
+{%- if "-introduction" not in block.slug and '-by-month' not in block.slug %}
+<div class="row">
 {{ brick(block, department, editing) }}
+</div>
 {%- endif %}
 {%- endfor %}
 


### PR DESCRIPTION
This branch makes a number of modifications to get the first chart above the fold.

![screen shot 2016-01-13 at 4 58 03 pm](https://cloud.githubusercontent.com/assets/451510/12313201/4c647988-ba1a-11e5-8d54-3764a322a00e.png)

There are some unresolved changes:

This introduces a conflict regarding #35. On `master`, intro text is represented as a brick, but we would rather use a 1-2 sentence intro and move all the other text into an "About" page (#35).
This branch simply ignores the introductory text, without solving #35.