### PR TITLE
Fix type mismatch

### DIFF
--- a/comport/data/cleaners.py
+++ b/comport/data/cleaners.py
@@ -90,6 +90,33 @@ class Cleaners:
         else:
             return titlecase(text)
 
+    def number_to_string(value):
+        ''' If it's a number, turn the passed value into a string, everything else is returned as-is.
+        '''
+        type_value = type(value)
+        if type_value == int or type_value == float:
+            return str(value)
+        return value
+
+    def string_to_integer(value):
+        ''' Strings and floats are turned to integers, integers are returned as-is, everything else is None.
+        '''
+        if type(value) == str:
+            try:
+                value_int = int(value)
+            except ValueError:
+                try:
+                    value_int = int(float(value))
+                except ValueError:
+                    value_int = None
+
+            return value_int
+        if type(value) == int:
+            return value
+        if type(value) == float:
+            return int(value)
+        return None
+
     def capitalize(value):
         def abbreviations(word, **kwargs):
             if word.upper() in CAPITALIZE_LIST:

--- a/comport/data/views.py
+++ b/comport/data/views.py
@@ -41,21 +41,27 @@ def use_of_force():
 
     for incident in j['data']:
 
-        division = Cleaners.capitalize(incident["division"])
-        precinct = Cleaners.capitalize(incident["precinct"])
-        shift = Cleaners.capitalize(incident["shift"])
-        beat = Cleaners.capitalize(incident["beat"])
-        officer_force_type = Cleaners.officer_force_type(incident["officerForceType"])
-        resident_race = Cleaners.race(incident["residentRace"])
-        resident_sex = Cleaners.sex(incident["residentSex"])
-        officer_race = Cleaners.race(incident["officerRace"])
-        officer_sex = Cleaners.sex(incident["officerSex"])
+        # capitalize the location
+        incident["division"] = Cleaners.capitalize(incident["division"])
+        incident["precinct"] = Cleaners.capitalize(incident["precinct"])
+        incident["shift"] = Cleaners.capitalize(incident["shift"])
+        incident["beat"] = Cleaners.capitalize(incident["beat"])
+        # clean force type, race, gender
+        incident["officerForceType"] = Cleaners.officer_force_type(incident["officerForceType"])
+        incident["residentRace"] = Cleaners.race(incident["residentRace"])
+        incident["residentSex"] = Cleaners.sex(incident["residentSex"])
+        incident["officerRace"] = Cleaners.race(incident["officerRace"])
+        incident["officerSex"] = Cleaners.sex(incident["officerSex"])
+        # make sure values that might've been sent as integers are strings
+        incident["residentAge"] = Cleaners.number_to_string(incident["residentAge"])
+        incident["officerAge"] = Cleaners.number_to_string(incident["officerAge"])
+        incident["officerYearsOfService"] = Cleaners.number_to_string(incident["officerYearsOfService"])
 
         found_incident = UseOfForceIncident.query.filter_by(
             opaque_id=incident["opaqueId"],
             department_id=department_id,
             officer_identifier=incident["officerIdentifier"],
-            officer_force_type=officer_force_type
+            officer_force_type=incident["officerForceType"]
         ).first()
 
         occured_date = parse_date(incident["occuredDate"])
@@ -65,13 +71,13 @@ def use_of_force():
                 department_id=department_id,
                 opaque_id=incident["opaqueId"],
                 occured_date=occured_date,
-                division=division,
-                precinct=precinct,
-                shift=shift,
-                beat=beat,
+                division=incident["division"],
+                precinct=incident["precinct"],
+                shift=incident["shift"],
+                beat=incident["beat"],
                 disposition=incident["disposition"],
                 census_tract=None,
-                officer_force_type=officer_force_type,
+                officer_force_type=incident["officerForceType"],
                 use_of_force_reason=incident["useOfForceReason"],
                 service_type=incident["serviceType"],
                 arrest_made=incident["arrestMade"],
@@ -81,13 +87,13 @@ def use_of_force():
                 resident_hospitalized=incident["residentHospitalized"],
                 officer_injured=incident["officerInjured"],
                 officer_hospitalized=incident["officerHospitalized"],
-                resident_race=resident_race,
-                resident_sex=resident_sex,
+                resident_race=incident["residentRace"],
+                resident_sex=incident["residentSex"],
                 resident_age=incident["residentAge"],
                 resident_condition=incident["residentCondition"],
                 officer_identifier=incident["officerIdentifier"],
-                officer_race=officer_race,
-                officer_sex=officer_sex,
+                officer_race=incident["officerRace"],
+                officer_sex=incident["officerSex"],
                 officer_age=incident["officerAge"],
                 officer_years_of_service=incident["officerYearsOfService"],
                 officer_condition=incident["officerCondition"]
@@ -98,13 +104,13 @@ def use_of_force():
         found_incident.department_id = department_id
         found_incident.opaque_id = incident["opaqueId"]
         found_incident.occured_date = occured_date
-        found_incident.division = division
-        found_incident.precinct = precinct
-        found_incident.shift = shift
-        found_incident.beat = beat
+        found_incident.division = incident["division"]
+        found_incident.precinct = incident["precinct"]
+        found_incident.shift = incident["shift"]
+        found_incident.beat = incident["beat"]
         found_incident.disposition = incident["disposition"]
         found_incident.census_tract = None
-        found_incident.officer_force_type = officer_force_type
+        found_incident.officer_force_type = incident["officerForceType"]
         found_incident.use_of_force_reason = incident["useOfForceReason"]
         found_incident.service_type = incident["serviceType"]
         found_incident.arrest_made = incident["arrestMade"]
@@ -114,13 +120,13 @@ def use_of_force():
         found_incident.resident_hospitalized = incident["residentHospitalized"]
         found_incident.officer_injured = incident["officerInjured"]
         found_incident.officer_hospitalized = incident["officerHospitalized"]
-        found_incident.resident_race = resident_race
-        found_incident.resident_sex = resident_sex
+        found_incident.resident_race = incident["residentRace"]
+        found_incident.resident_sex = incident["residentSex"]
         found_incident.resident_age = incident["residentAge"]
         found_incident.resident_condition = incident["residentCondition"]
         found_incident.officer_identifier = incident["officerIdentifier"]
-        found_incident.officer_race = officer_race
-        found_incident.officer_sex = officer_sex
+        found_incident.officer_race = incident["officerRace"]
+        found_incident.officer_sex = incident["officerSex"]
         found_incident.officer_age = incident["officerAge"]
         found_incident.officer_years_of_service = incident["officerYearsOfService"]
         found_incident.officer_condition = incident["officerCondition"]
@@ -145,15 +151,22 @@ def officer_involved_shooting():
 
     for incident in request_json['data']:
 
-        resident_weapon_used = Cleaners.resident_weapon_used(incident["residentWeaponUsed"])
-        resident_sex = Cleaners.sex(incident["residentSex"])
-        resident_race = Cleaners.race(incident["residentRace"])
-        officer_sex = Cleaners.sex(incident["officerSex"])
-        officer_race = Cleaners.race(incident["officerRace"])
-        precinct = Cleaners.capitalize(incident["precinct"])
-        division = Cleaners.capitalize(incident["division"])
-        shift = Cleaners.capitalize(incident["shift"])
-        beat = Cleaners.capitalize(incident["beat"])
+        # capitalize the location
+        incident["division"] = Cleaners.capitalize(incident["division"])
+        incident["precinct"] = Cleaners.capitalize(incident["precinct"])
+        incident["shift"] = Cleaners.capitalize(incident["shift"])
+        incident["beat"] = Cleaners.capitalize(incident["beat"])
+        # clean weapon, race, gender
+        incident["residentWeaponUsed"] = Cleaners.resident_weapon_used(incident["residentWeaponUsed"])
+        incident["residentSex"] = Cleaners.sex(incident["residentSex"])
+        incident["residentRace"] = Cleaners.race(incident["residentRace"])
+        incident["officerSex"] = Cleaners.sex(incident["officerSex"])
+        incident["officerRace"] = Cleaners.race(incident["officerRace"])
+        # make sure values that might've been sent as integers are strings
+        incident["residentAge"] = Cleaners.number_to_string(incident["residentAge"])
+        incident["officerAge"] = Cleaners.number_to_string(incident["officerAge"])
+        # and values that might've been sent as strings are integers
+        incident["officerYearsOfService"] = Cleaners.string_to_integer(incident["officerYearsOfService"])
 
         found_incident = OfficerInvolvedShooting.query.filter_by(
             opaque_id=incident["opaqueId"],
@@ -169,20 +182,20 @@ def officer_involved_shooting():
                 opaque_id=incident["opaqueId"],
                 service_type=incident["serviceType"],
                 occured_date=occured_date,
-                division=division,
-                precinct=precinct,
-                shift=shift,
-                beat=beat,
+                division=incident["division"],
+                precinct=incident["precinct"],
+                shift=incident["shift"],
+                beat=incident["beat"],
                 disposition=incident["disposition"],
-                resident_race=resident_race,
-                resident_sex=resident_sex,
+                resident_race=incident["residentRace"],
+                resident_sex=incident["residentSex"],
                 resident_age=incident["residentAge"],
-                resident_weapon_used=resident_weapon_used,
+                resident_weapon_used=incident["residentWeaponUsed"],
                 resident_condition=incident["residentCondition"],
                 officer_identifier=incident["officerIdentifier"],
                 officer_weapon_used=incident["officerForceType"],
-                officer_race=officer_race,
-                officer_sex=officer_sex,
+                officer_race=incident["officerRace"],
+                officer_sex=incident["officerSex"],
                 officer_age=incident["officerAge"],
                 officer_years_of_service=parse_int(incident["officerYearsOfService"]),
                 officer_condition=incident["officerCondition"],
@@ -195,20 +208,20 @@ def officer_involved_shooting():
         found_incident.opaque_id = incident["opaqueId"]
         found_incident.service_type = incident["serviceType"]
         found_incident.occured_date = occured_date
-        found_incident.division = division
-        found_incident.precinct = precinct
-        found_incident.shift = shift
-        found_incident.beat = beat
+        found_incident.division = incident["division"]
+        found_incident.precinct = incident["precinct"]
+        found_incident.shift = incident["shift"]
+        found_incident.beat = incident["beat"]
         found_incident.disposition = incident["disposition"]
-        found_incident.resident_race = resident_race
-        found_incident.resident_sex = resident_sex
+        found_incident.resident_race = incident["residentRace"]
+        found_incident.resident_sex = incident["residentSex"]
         found_incident.resident_age = incident["residentAge"]
-        found_incident.resident_weapon_used = resident_weapon_used
+        found_incident.resident_weapon_used = incident["residentWeaponUsed"]
         found_incident.resident_condition = incident["residentCondition"]
         found_incident.officer_identifier = incident["officerIdentifier"]
         found_incident.officer_weapon_used = incident["officerForceType"]
-        found_incident.officer_race = officer_race
-        found_incident.officer_sex = officer_sex
+        found_incident.officer_race = incident["officerRace"]
+        found_incident.officer_sex = incident["officerSex"]
         found_incident.officer_age = incident["officerAge"]
         found_incident.officer_years_of_service = parse_int(incident["officerYearsOfService"])
         found_incident.officer_condition = incident["officerCondition"]
@@ -236,10 +249,14 @@ def complaints():
         # capitalize all the fields in the incident
         incident = Cleaners.capitalize_incident(incident)
         # clean sex & race
-        resident_sex = Cleaners.sex(incident["residentSex"])
-        resident_race = Cleaners.race(incident["residentRace"])
-        officer_sex = Cleaners.sex(incident["officerSex"])
-        officer_race = Cleaners.race(incident["officerRace"])
+        incident["residentSex"] = Cleaners.sex(incident["residentSex"])
+        incident["residentRace"] = Cleaners.race(incident["residentRace"])
+        incident["officerSex"] = Cleaners.sex(incident["officerSex"])
+        incident["officerRace"] = Cleaners.race(incident["officerRace"])
+        # make sure values that might've been sent as integers are strings
+        incident["residentAge"] = Cleaners.number_to_string(incident["residentAge"])
+        incident["officerAge"] = Cleaners.number_to_string(incident["officerAge"])
+        incident["officerYearsOfService"] = Cleaners.number_to_string(incident["officerYearsOfService"])
 
         found_incident = CitizenComplaint.query.filter_by(
             opaque_id=incident["opaqueId"],
@@ -247,8 +264,8 @@ def complaints():
             allegation=incident["allegation"],
             officer_identifier=incident["officerIdentifier"],
             department_id=department_id,
-            resident_race=resident_race,
-            resident_sex=resident_sex,
+            resident_race=incident["residentRace"],
+            resident_sex=incident["residentSex"],
             resident_age=incident["residentAge"]
         ).first()
 
@@ -280,12 +297,12 @@ def complaints():
                 allegation_type=incident["allegationType"],
                 allegation=incident["allegation"],
                 disposition=incident["disposition"],
-                resident_race=resident_race,
-                resident_sex=resident_sex,
+                resident_race=incident["residentRace"],
+                resident_sex=incident["residentSex"],
                 resident_age=incident["residentAge"],
                 officer_identifier=incident["officerIdentifier"],
-                officer_race=officer_race,
-                officer_sex=officer_sex,
+                officer_race=incident["officerRace"],
+                officer_sex=incident["officerSex"],
                 officer_age=incident["officerAge"],
                 officer_years_of_service=incident["officerYearsOfService"],
                 census_tract=None
@@ -306,12 +323,12 @@ def complaints():
         found_incident.allegation_type = incident["allegationType"]
         found_incident.allegation = incident["allegation"]
         found_incident.disposition = incident["disposition"]
-        found_incident.resident_race = resident_race
-        found_incident.resident_sex = resident_sex
+        found_incident.resident_race = incident["residentRace"]
+        found_incident.resident_sex = incident["residentSex"]
         found_incident.resident_age = incident["residentAge"]
         found_incident.officer_identifier = incident["officerIdentifier"]
-        found_incident.officer_race = officer_race
-        found_incident.officer_sex = officer_sex
+        found_incident.officer_race = incident["officerRace"]
+        found_incident.officer_sex = incident["officerSex"]
         found_incident.officer_age = incident["officerAge"]
         found_incident.officer_years_of_service = incident["officerYearsOfService"]
         found_incident.census_tract = None

--- a/comport/data/views.py
+++ b/comport/data/views.py
@@ -246,6 +246,10 @@ def complaints():
     updated_rows = 0
 
     for incident in j['data']:
+        # make sure values that might've been sent as integers are strings
+        incident["residentAge"] = Cleaners.number_to_string(incident["residentAge"])
+        incident["officerAge"] = Cleaners.number_to_string(incident["officerAge"])
+        incident["officerYearsOfService"] = Cleaners.number_to_string(incident["officerYearsOfService"])
         # capitalize all the fields in the incident
         incident = Cleaners.capitalize_incident(incident)
         # clean sex & race
@@ -253,10 +257,6 @@ def complaints():
         incident["residentRace"] = Cleaners.race(incident["residentRace"])
         incident["officerSex"] = Cleaners.sex(incident["officerSex"])
         incident["officerRace"] = Cleaners.race(incident["officerRace"])
-        # make sure values that might've been sent as integers are strings
-        incident["residentAge"] = Cleaners.number_to_string(incident["residentAge"])
-        incident["officerAge"] = Cleaners.number_to_string(incident["officerAge"])
-        incident["officerYearsOfService"] = Cleaners.number_to_string(incident["officerYearsOfService"])
 
         found_incident = CitizenComplaint.query.filter_by(
             opaque_id=incident["opaqueId"],

--- a/tests/test_cleaners.py
+++ b/tests/test_cleaners.py
@@ -102,3 +102,35 @@ class TestCleaners:
         # values of keys in the list should not be titlecased
         for key in CAPITALIZE_IGNORE_KEYS_LIST:
             assert result[key] == in_sentence
+
+    def test_number_to_string(self):
+        ''' Numbers are turned into strings.
+        '''
+        in_int = 85
+        in_float = 82.12
+        in_string = "big frame, small spirit!"
+        in_list = ["hands", "by", "the", "halyards"]
+        in_none = None
+        assert Cleaners.number_to_string(in_int) == str(in_int)
+        assert Cleaners.number_to_string(in_float) == str(in_float)
+        assert Cleaners.number_to_string(in_string) == in_string
+        assert Cleaners.number_to_string(in_list) == in_list
+        assert Cleaners.number_to_string(in_none) is None
+
+    def test_string_to_integer(self):
+        ''' Strings are turned into integers.
+        '''
+        in_string_success_int = '85'
+        in_string_success_float = '33.34'
+        in_int = 85
+        in_float = 82.12
+        in_string_fail = 'whaleman'
+        in_list = ["hands", "by", "the", "halyards"]
+        in_none = None
+        assert Cleaners.string_to_integer(in_string_success_int) == int(in_string_success_int)
+        assert Cleaners.string_to_integer(in_string_success_float) == int(float(in_string_success_float))
+        assert Cleaners.string_to_integer(in_int) == in_int
+        assert Cleaners.string_to_integer(in_float) == int(in_float)
+        assert Cleaners.string_to_integer(in_string_fail) is None
+        assert Cleaners.string_to_integer(in_list) is None
+        assert Cleaners.string_to_integer(in_none) is None

--- a/tests/test_extractor_api.py
+++ b/tests/test_extractor_api.py
@@ -84,12 +84,62 @@ class TestHeartbeat:
         assert check_complaint.allegation == sent_complaint['allegation']
         assert check_complaint.resident_race == Cleaners.race(sent_complaint['residentRace'])
         assert check_complaint.resident_sex == Cleaners.sex(sent_complaint['residentSex'])
-        assert check_complaint.resident_age == sent_complaint['residentAge']
+        assert check_complaint.resident_age == Cleaners.number_to_string(sent_complaint['residentAge'])
         assert check_complaint.officer_identifier == sent_complaint['officerIdentifier']
         assert check_complaint.officer_race == Cleaners.race(sent_complaint['officerRace'])
         assert check_complaint.officer_sex == Cleaners.sex(sent_complaint['officerSex'])
-        assert check_complaint.officer_age == sent_complaint['officerAge']
-        assert check_complaint.officer_years_of_service == sent_complaint['officerYearsOfService']
+        assert check_complaint.officer_age == Cleaners.number_to_string(sent_complaint['officerAge'])
+        assert check_complaint.officer_years_of_service == Cleaners.number_to_string(sent_complaint['officerYearsOfService'])
+
+    def test_post_mistyped_complaint_data(self, testapp):
+        ''' New complaint data from the extractor with wrongly typed data is processed as expected.
+        '''
+        # Set up the extractor
+        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        extractor, envs = Extractor.from_department_and_password(department=department, password="password")
+
+        # Set the correct authorization
+        testapp.authorization = ('Basic', (extractor.username, 'password'))
+
+        # Get a generated list of complaint descriptions from the JSON test client
+        test_client = JSONTestClient()
+        complaint_count = 1
+        complaint_data = test_client.get_prebaked_complaints(last=complaint_count)
+
+        # The app expects number values to be transmitted as strings. Let's change them to integers.
+        complaint_data[0]['residentAge'] = 28
+        complaint_data[0]['officerAge'] = 46
+        complaint_data[0]['officerYearsOfService'] = 17
+
+        # post the json to the complaint URL
+        response = testapp.post_json("/data/complaints", params={'month': 0, 'year': 0, 'data': complaint_data})
+
+        # assert that we got the expected reponse
+        assert response.status_code == 200
+        assert response.json_body['updated'] == 0
+        assert response.json_body['added'] == complaint_count
+
+        # check the complaint incident in the database against the data that was sent
+        sent_complaint = Cleaners.capitalize_incident(complaint_data[0])
+        check_complaint = CitizenComplaint.query.filter_by(opaque_id=sent_complaint['opaqueId']).first()
+        assert check_complaint.occured_date.strftime('%Y-%m-%d %-H:%-M:%S') == sent_complaint['occuredDate']
+        assert check_complaint.division == sent_complaint['division']
+        assert check_complaint.precinct == sent_complaint['precinct']
+        assert check_complaint.shift == sent_complaint['shift']
+        assert check_complaint.beat == sent_complaint['beat']
+        assert check_complaint.disposition == sent_complaint['disposition']
+        assert check_complaint.service_type == sent_complaint['serviceType']
+        assert check_complaint.source == sent_complaint['source']
+        assert check_complaint.allegation_type == sent_complaint['allegationType']
+        assert check_complaint.allegation == sent_complaint['allegation']
+        assert check_complaint.resident_race == Cleaners.race(sent_complaint['residentRace'])
+        assert check_complaint.resident_sex == Cleaners.sex(sent_complaint['residentSex'])
+        assert check_complaint.resident_age == Cleaners.number_to_string(sent_complaint['residentAge'])
+        assert check_complaint.officer_identifier == sent_complaint['officerIdentifier']
+        assert check_complaint.officer_race == Cleaners.race(sent_complaint['officerRace'])
+        assert check_complaint.officer_sex == Cleaners.sex(sent_complaint['officerSex'])
+        assert check_complaint.officer_age == Cleaners.number_to_string(sent_complaint['officerAge'])
+        assert check_complaint.officer_years_of_service == Cleaners.number_to_string(sent_complaint['officerYearsOfService'])
 
     def test_update_complaint_data(self, testapp):
         ''' Updated complaint data from the extractor is processed as expected.
@@ -150,12 +200,12 @@ class TestHeartbeat:
         assert check_complaint.allegation == sent_complaint['allegation']
         assert check_complaint.resident_race == Cleaners.race(sent_complaint['residentRace'])
         assert check_complaint.resident_sex == Cleaners.sex(sent_complaint['residentSex'])
-        assert check_complaint.resident_age == sent_complaint['residentAge']
+        assert check_complaint.resident_age == Cleaners.number_to_string(sent_complaint['residentAge'])
         assert check_complaint.officer_identifier == sent_complaint['officerIdentifier']
         assert check_complaint.officer_race == Cleaners.race(sent_complaint['officerRace'])
         assert check_complaint.officer_sex == Cleaners.sex(sent_complaint['officerSex'])
-        assert check_complaint.officer_age == sent_complaint['officerAge']
-        assert check_complaint.officer_years_of_service == sent_complaint['officerYearsOfService']
+        assert check_complaint.officer_age == Cleaners.number_to_string(sent_complaint['officerAge'])
+        assert check_complaint.officer_years_of_service == Cleaners.number_to_string(sent_complaint['officerYearsOfService'])
 
     def test_skip_multiple_complaint_data(self, testapp):
         ''' Multiple complaint data from the extractor is skipped.
@@ -278,13 +328,71 @@ class TestHeartbeat:
         assert check_uof.officer_hospitalized == sent_uof['officerHospitalized']
         assert check_uof.resident_race == Cleaners.race(sent_uof['residentRace'])
         assert check_uof.resident_sex == Cleaners.sex(sent_uof['residentSex'])
-        assert check_uof.resident_age == sent_uof['residentAge']
+        assert check_uof.resident_age == Cleaners.number_to_string(sent_uof['residentAge'])
         assert check_uof.resident_condition == sent_uof['residentCondition']
         assert check_uof.officer_identifier == sent_uof['officerIdentifier']
         assert check_uof.officer_race == Cleaners.race(sent_uof['officerRace'])
         assert check_uof.officer_sex == Cleaners.sex(sent_uof['officerSex'])
-        assert check_uof.officer_age == sent_uof['officerAge']
-        assert check_uof.officer_years_of_service == sent_uof['officerYearsOfService']
+        assert check_uof.officer_age == Cleaners.number_to_string(sent_uof['officerAge'])
+        assert check_uof.officer_years_of_service == Cleaners.number_to_string(sent_uof['officerYearsOfService'])
+        assert check_uof.officer_condition == sent_uof['officerCondition']
+
+    def test_post_mistyped_uof_data(self, testapp):
+        ''' New UOF data from the extractor is processed as expected.
+        '''
+        # Set up the extractor
+        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        extractor, envs = Extractor.from_department_and_password(department=department, password="password")
+
+        # Set the correct authorization
+        testapp.authorization = ('Basic', (extractor.username, 'password'))
+
+        # Get a generated list of UOF descriptions from the JSON test client
+        test_client = JSONTestClient()
+        uof_count = 1
+        uof_data = test_client.get_prebaked_uof(last=uof_count)
+
+        # The app expects number values to be transmitted as strings. Let's change them to integers.
+        uof_data[0]['residentAge'] = 28
+        uof_data[0]['officerAge'] = 46
+        uof_data[0]['officerYearsOfService'] = 17
+
+        # post the json to the UOF URL
+        response = testapp.post_json("/data/UOF", params={'month': 0, 'year': 0, 'data': uof_data})
+
+        # assert that we got the expected reponse
+        assert response.status_code == 200
+        assert response.json_body['updated'] == 0
+        assert response.json_body['added'] == uof_count
+
+        # check the uof incident in the database against the data that was sent
+        sent_uof = uof_data[0]
+        check_uof = UseOfForceIncident.query.filter_by(opaque_id=sent_uof['opaqueId']).first()
+        assert check_uof.occured_date.strftime('%Y-%m-%d %-H:%-M:%S') == sent_uof['occuredDate']
+        assert check_uof.division == Cleaners.capitalize(sent_uof['division'])
+        assert check_uof.precinct == Cleaners.capitalize(sent_uof['precinct'])
+        assert check_uof.shift == Cleaners.capitalize(sent_uof['shift'])
+        assert check_uof.beat == Cleaners.capitalize(sent_uof['beat'])
+        assert check_uof.disposition == sent_uof['disposition']
+        assert check_uof.officer_force_type == Cleaners.officer_force_type(sent_uof['officerForceType'])
+        assert check_uof.use_of_force_reason == sent_uof['useOfForceReason']
+        assert check_uof.service_type == sent_uof['serviceType']
+        assert check_uof.arrest_made == sent_uof['arrestMade']
+        assert check_uof.arrest_charges == sent_uof['arrestCharges']
+        assert check_uof.resident_weapon_used == sent_uof['residentWeaponUsed']
+        assert check_uof.resident_injured == sent_uof['residentInjured']
+        assert check_uof.resident_hospitalized == sent_uof['residentHospitalized']
+        assert check_uof.officer_injured == sent_uof['officerInjured']
+        assert check_uof.officer_hospitalized == sent_uof['officerHospitalized']
+        assert check_uof.resident_race == Cleaners.race(sent_uof['residentRace'])
+        assert check_uof.resident_sex == Cleaners.sex(sent_uof['residentSex'])
+        assert check_uof.resident_age == Cleaners.number_to_string(sent_uof['residentAge'])
+        assert check_uof.resident_condition == sent_uof['residentCondition']
+        assert check_uof.officer_identifier == sent_uof['officerIdentifier']
+        assert check_uof.officer_race == Cleaners.race(sent_uof['officerRace'])
+        assert check_uof.officer_sex == Cleaners.sex(sent_uof['officerSex'])
+        assert check_uof.officer_age == Cleaners.number_to_string(sent_uof['officerAge'])
+        assert check_uof.officer_years_of_service == Cleaners.number_to_string(sent_uof['officerYearsOfService'])
         assert check_uof.officer_condition == sent_uof['officerCondition']
 
     def test_update_uof_data(self, testapp):
@@ -348,13 +456,13 @@ class TestHeartbeat:
         assert check_uof.officer_hospitalized == sent_uof['officerHospitalized']
         assert check_uof.resident_race == Cleaners.race(sent_uof['residentRace'])
         assert check_uof.resident_sex == Cleaners.sex(sent_uof['residentSex'])
-        assert check_uof.resident_age == sent_uof['residentAge']
+        assert check_uof.resident_age == Cleaners.number_to_string(sent_uof['residentAge'])
         assert check_uof.resident_condition == sent_uof['residentCondition']
         assert check_uof.officer_identifier == sent_uof['officerIdentifier']
         assert check_uof.officer_race == Cleaners.race(sent_uof['officerRace'])
         assert check_uof.officer_sex == Cleaners.sex(sent_uof['officerSex'])
-        assert check_uof.officer_age == sent_uof['officerAge']
-        assert check_uof.officer_years_of_service == sent_uof['officerYearsOfService']
+        assert check_uof.officer_age == Cleaners.number_to_string(sent_uof['officerAge'])
+        assert check_uof.officer_years_of_service == Cleaners.number_to_string(sent_uof['officerYearsOfService'])
         assert check_uof.officer_condition == sent_uof['officerCondition']
 
     def test_post_uof_data_near_match_does_not_update(self, testapp):
@@ -427,15 +535,66 @@ class TestHeartbeat:
         assert check_ois.disposition == sent_ois['disposition']
         assert check_ois.resident_race == Cleaners.race(sent_ois['residentRace'])
         assert check_ois.resident_sex == Cleaners.sex(sent_ois['residentSex'])
-        assert check_ois.resident_age == sent_ois['residentAge']
+        assert check_ois.resident_age == Cleaners.number_to_string(sent_ois['residentAge'])
         assert check_ois.resident_weapon_used == Cleaners.resident_weapon_used(sent_ois['residentWeaponUsed'])
         assert check_ois.resident_condition == sent_ois['residentCondition']
         assert check_ois.officer_identifier == sent_ois['officerIdentifier']
         assert check_ois.officer_weapon_used == sent_ois['officerForceType']
         assert check_ois.officer_race == Cleaners.race(sent_ois['officerRace'])
         assert check_ois.officer_sex == Cleaners.sex(sent_ois['officerSex'])
-        assert check_ois.officer_age == sent_ois['officerAge']
-        assert check_ois.officer_years_of_service == sent_ois['officerYearsOfService']
+        assert check_ois.officer_age == Cleaners.number_to_string(sent_ois['officerAge'])
+        assert check_ois.officer_years_of_service == Cleaners.string_to_integer(sent_ois['officerYearsOfService'])
+        assert check_ois.officer_condition == sent_ois['officerCondition']
+
+    def test_post_mistyped_ois_data(self, testapp):
+        ''' New OIS data from the extractor is processed as expected.
+        '''
+        # Set up the extractor
+        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        extractor, envs = Extractor.from_department_and_password(department=department, password="password")
+
+        # Set the correct authorization
+        testapp.authorization = ('Basic', (extractor.username, 'password'))
+
+        # Get a generated list of OIS descriptions from the JSON test client
+        test_client = JSONTestClient()
+        ois_count = 1
+        ois_data = test_client.get_prebaked_ois(last=ois_count)
+
+        # The app expects number values to be transmitted as strings. Let's change them to integers.
+        ois_data[0]['residentAge'] = 28
+        ois_data[0]['officerAge'] = 46
+        # And it expects this number value to be transmitted as a number, so let's make it a string.
+        ois_data[0]['officerYearsOfService'] = "17"
+
+        # post the json to the OIS URL
+        response = testapp.post_json("/data/OIS", params={'month': 0, 'year': 0, 'data': ois_data})
+
+        # assert that we got the expected reponse
+        assert response.status_code == 200
+        assert response.json_body['updated'] == 0
+        assert response.json_body['added'] == ois_count
+
+        # check the ois incident in the database against the data that was sent
+        sent_ois = ois_data[0]
+        check_ois = OfficerInvolvedShooting.query.filter_by(opaque_id=sent_ois['opaqueId']).first()
+        assert check_ois.occured_date.strftime('%Y-%m-%d %-H:%-M:%S') == sent_ois['occuredDate']
+        assert check_ois.division == Cleaners.capitalize(sent_ois['division'])
+        assert check_ois.precinct == Cleaners.capitalize(sent_ois['precinct'])
+        assert check_ois.shift == Cleaners.capitalize(sent_ois['shift'])
+        assert check_ois.beat == Cleaners.capitalize(sent_ois['beat'])
+        assert check_ois.disposition == sent_ois['disposition']
+        assert check_ois.resident_race == Cleaners.race(sent_ois['residentRace'])
+        assert check_ois.resident_sex == Cleaners.sex(sent_ois['residentSex'])
+        assert check_ois.resident_age == Cleaners.number_to_string(sent_ois['residentAge'])
+        assert check_ois.resident_weapon_used == Cleaners.resident_weapon_used(sent_ois['residentWeaponUsed'])
+        assert check_ois.resident_condition == sent_ois['residentCondition']
+        assert check_ois.officer_identifier == sent_ois['officerIdentifier']
+        assert check_ois.officer_weapon_used == sent_ois['officerForceType']
+        assert check_ois.officer_race == Cleaners.race(sent_ois['officerRace'])
+        assert check_ois.officer_sex == Cleaners.sex(sent_ois['officerSex'])
+        assert check_ois.officer_age == Cleaners.number_to_string(sent_ois['officerAge'])
+        assert check_ois.officer_years_of_service == Cleaners.string_to_integer(sent_ois['officerYearsOfService'])
         assert check_ois.officer_condition == sent_ois['officerCondition']
 
     def test_update_ois_data(self, testapp):
@@ -488,15 +647,15 @@ class TestHeartbeat:
         assert check_ois.disposition == sent_ois['disposition']
         assert check_ois.resident_race == Cleaners.race(sent_ois['residentRace'])
         assert check_ois.resident_sex == Cleaners.sex(sent_ois['residentSex'])
-        assert check_ois.resident_age == sent_ois['residentAge']
+        assert check_ois.resident_age == Cleaners.number_to_string(sent_ois['residentAge'])
         assert check_ois.resident_weapon_used == Cleaners.resident_weapon_used(sent_ois['residentWeaponUsed'])
         assert check_ois.resident_condition == sent_ois['residentCondition']
         assert check_ois.officer_identifier == sent_ois['officerIdentifier']
         assert check_ois.officer_weapon_used == sent_ois['officerForceType']
         assert check_ois.officer_race == Cleaners.race(sent_ois['officerRace'])
         assert check_ois.officer_sex == Cleaners.sex(sent_ois['officerSex'])
-        assert check_ois.officer_age == sent_ois['officerAge']
-        assert check_ois.officer_years_of_service == sent_ois['officerYearsOfService']
+        assert check_ois.officer_age == Cleaners.number_to_string(sent_ois['officerAge'])
+        assert check_ois.officer_years_of_service == Cleaners.string_to_integer(sent_ois['officerYearsOfService'])
         assert check_ois.officer_condition == sent_ois['officerCondition']
 
     def test_post_ois_data_near_match_does_not_update(self, testapp):


### PR DESCRIPTION
Complaints data from the extractor were failing with type mismatch errors–certain values expected to be strings were actually integers. This tests for and fixes that scenario.