### PR TITLE
Added encoding to defaults.py

### DIFF
--- a/comport/content/defaults.py
+++ b/comport/content/defaults.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from .models import ChartBlock
 
 class ChartBlockDefaults:


### PR DESCRIPTION
I got an error on installation about lack of declared encoding in this file.  This should fix it.