### PR TITLE
Add slack webhooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ Temporary Items
 .apdisk
 
 data/testdata/*
+
+.env

--- a/README.md
+++ b/README.md
@@ -35,8 +35,15 @@ python manage.py db upgrade
 python manage.py server
 ```
 
-
 **NOTE**: The app's configuration lives in [`settings.py`](https://github.com/codeforamerica/comport/blob/master/comport/settings.py). When different configurations (such as `DevConfig`) are referenced in the next sections, they are contained in that file.
+
+If you want to send a notification to a Slack instance on certain events, copy the `env.sample` file to `.env`:
+
+```
+cp env.sample .env
+```
+
+[Set up an Incoming Webhooks integration on Slack](https://my.slack.com/services/new/incoming-webhook) and save the value of **Webhook URL** as `SLACK_WEBHOOK_URL` in `.env`. This will work when you're running Comport locally. To set the variable when the application is running on Heroku, [follow these instructions](https://devcenter.heroku.com/articles/config-vars).
 
 #### Testing
 

--- a/comport/app.py
+++ b/comport/app.py
@@ -27,7 +27,12 @@ def create_app(config_object=ProdConfig):
     """
     app = Flask(__name__)
     sslify = SSLify(app)
+
+    # set config from the passed object
     app.config.from_object(config_object)
+    # set additional config values from environ
+    app.config['SLACK_WEBHOOK_URL'] = os.environ['SLACK_WEBHOOK_URL']
+
     register_extensions(app)
     register_blueprints(app)
     register_errorhandlers(app)

--- a/comport/app.py
+++ b/comport/app.py
@@ -31,7 +31,7 @@ def create_app(config_object=ProdConfig):
     # set config from the passed object
     app.config.from_object(config_object)
     # set additional config values from environ
-    app.config['SLACK_WEBHOOK_URL'] = os.environ['SLACK_WEBHOOK_URL']
+    app.config['SLACK_WEBHOOK_URL'] = os.environ.get('SLACK_WEBHOOK_URL')
 
     register_extensions(app)
     register_blueprints(app)

--- a/comport/data/views.py
+++ b/comport/data/views.py
@@ -25,7 +25,13 @@ def heartbeat():
     extractor.save()
 
     heartbeat_response = json.dumps({"received": request.json})
-    slack_body_lines = ['For: {}'.format(extractor.first_department().name)]
+    slack_body_lines = []
+    extractor_department = extractor.first_department()
+    if extractor_department:
+        slack_body_lines.append('For: {}'.format(extractor_department.name))
+    else:
+        slack_body_lines.append('Username: {}'.format(username))
+
     slack_date_line = 'No extraction start date in reply.'
 
     if extractor.next_month and extractor.next_year:

--- a/comport/data/views.py
+++ b/comport/data/views.py
@@ -3,7 +3,8 @@ from flask import Blueprint, request
 from comport.decorators import extractor_auth_required
 from comport.department.models import Extractor
 from comport.data.models import UseOfForceIncident, CitizenComplaint, OfficerInvolvedShooting
-from comport.utils import parse_date, parse_int
+from comport.utils import parse_date, parse_int, send_slack_message
+
 from .cleaners import Cleaners
 
 import json
@@ -23,10 +24,18 @@ def heartbeat():
     extractor.last_contact = datetime.now()
     extractor.save()
 
-    if extractor.next_month and extractor.next_year:
-        return json.dumps({"received": request.json, "nextMonth": extractor.next_month, "nextYear": extractor.next_year})
+    heartbeat_response = json.dumps({"received": request.json})
+    slack_body_lines = ['For: {}'.format(extractor.first_department().name)]
+    slack_date_line = 'No extraction start date in reply.'
 
-    return json.dumps({"received": request.json})
+    if extractor.next_month and extractor.next_year:
+        heartbeat_response = json.dumps({"received": request.json, "nextMonth": extractor.next_month, "nextYear": extractor.next_year})
+        slack_date_line = 'Replied with extraction start date: {}/{}'.format(extractor.next_month, extractor.next_year)
+
+    slack_body_lines.append(slack_date_line)
+    send_slack_message('Comport Pinged by Extractor!', slack_body_lines)
+
+    return heartbeat_response
 
 
 @blueprint.route("/UOF", methods=['POST'])

--- a/comport/interest/views.py
+++ b/comport/interest/views.py
@@ -4,7 +4,7 @@ from flask import (Blueprint, request, render_template, flash, url_for, redirect
 
 from comport.interest.models import Interested
 from comport.interest.forms import InterestForm
-from comport.utils import flash_errors
+from comport.utils import flash_errors, send_slack_message
 
 blueprint = Blueprint('interest', __name__, url_prefix='/interest', static_folder="../static")
 
@@ -20,6 +20,8 @@ def home():
                 phone=form.phone.data,
                 email=form.email.data,
                 comments=form.comments.data)
+            # send a slack notification
+            send_slack_message('New Interest Form Submission!', '\n'.join([item for item in [form.name.data, form.agency.data, form.location.data, form.phone.data, form.email.data, form.comments.data] if item]))
             flash("Thank you. We will be in contact shortly.", 'success')
             return redirect(url_for('public.home'))
         else:

--- a/comport/interest/views.py
+++ b/comport/interest/views.py
@@ -21,7 +21,7 @@ def home():
                 email=form.email.data,
                 comments=form.comments.data)
             # send a slack notification
-            send_slack_message('New Interest Form Submission!', '\n'.join([item for item in [form.name.data, form.agency.data, form.location.data, form.phone.data, form.email.data, form.comments.data] if item]))
+            send_slack_message('New Interest Form Submission!', [form.name.data, form.agency.data, form.location.data, form.phone.data, form.email.data, form.comments.data])
             flash("Thank you. We will be in contact shortly.", 'success')
             return redirect(url_for('public.home'))
         else:

--- a/comport/settings.py
+++ b/comport/settings.py
@@ -1,11 +1,8 @@
 import os
 
-os_env = os.environ
-
-
 class Config(object):
-    SECRET_KEY = os_env.get('COMPORT_SECRET', 'comport-secret-key')
-    BASE_URL = os_env.get('BASE_URL', 'http://localhost:5000/')
+    SECRET_KEY = os.environ.get('COMPORT_SECRET', 'comport-secret-key')
+    BASE_URL = os.environ.get('BASE_URL', 'http://localhost:5000/')
     APP_DIR = os.path.abspath(os.path.dirname(__file__))  # This directory
     PROJECT_ROOT = os.path.abspath(os.path.join(APP_DIR, os.pardir))
     BCRYPT_LOG_ROUNDS = 13
@@ -14,30 +11,27 @@ class Config(object):
     DEBUG_TB_INTERCEPT_REDIRECTS = False
     CACHE_TYPE = 'simple'  # Can be "memcached", "redis", etc.
 
-
 class ProdConfig(Config):
     """Production configuration."""
     ENV = 'prod'
     DEBUG = False
-    SQLALCHEMY_DATABASE_URI = os_env.get('DATABASE_URL', 'postgresql://localhost/comport')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'postgresql://localhost/comport')
     DEBUG_TB_ENABLED = False  # Disable Debug toolbar
     ASSETS_DEBUG = True
-
 
 class DevConfig(Config):
     """Development configuration."""
     ENV = 'dev'
     DEBUG = True
-    SQLALCHEMY_DATABASE_URI = os_env.get('DATABASE_URL', 'postgresql://localhost/comport')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'postgresql://localhost/comport')
     DEBUG_TB_ENABLED = True
     ASSETS_DEBUG = True  # Don't bundle/minify static assets
     CACHE_TYPE = 'simple'  # Can be "memcached", "redis", etc.
 
-
 class TestConfig(Config):
     TESTING = True
     DEBUG = True
-    SQLALCHEMY_DATABASE_URI = os_env.get('TEST_DATABASE_URL', 'postgresql://localhost/comport_test')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL', 'postgresql://localhost/comport_test')
     BCRYPT_LOG_ROUNDS = 1  # For faster tests
     PRESERVE_CONTEXT_ON_EXCEPTION = False
     WTF_CSRF_ENABLED = False  # Allows form testing

--- a/comport/utils.py
+++ b/comport/utils.py
@@ -1,11 +1,26 @@
 # -*- coding: utf-8 -*-
 """Helper utilities and decorators."""
-from flask import flash
+from flask import flash, current_app
+import requests
+import json
 import string
 from random import randint, choice
 from datetime import datetime, timedelta
 from factory.fuzzy import _random
 
+def send_slack_message(title='', body=''):
+    ''' Send a slack webhook with the passed message
+    '''
+    # Only send if a Slack webhook URL has been set
+    webhook_url = current_app.config.get('SLACK_WEBHOOK_URL')
+    if webhook_url:
+        if title:
+            title = '*{}*\n'.format(title)
+        pretext = '{title}{body}'.format(title=title, body=body)
+        payload_values = dict(text=pretext)
+        payload = json.dumps(payload_values)
+        headers = {'Content-type': 'application/json'}
+        requests.post(webhook_url, data=payload, headers=headers)
 
 def flash_errors(form, category="warning"):
     """Flash all errors for a form."""

--- a/comport/utils.py
+++ b/comport/utils.py
@@ -8,16 +8,35 @@ from random import randint, choice
 from datetime import datetime, timedelta
 from factory.fuzzy import _random
 
-def send_slack_message(title='', body=''):
-    ''' Send a slack webhook with the passed message
+def slack_escape(str):
+    ''' Escape a string to be sent to Slack, as per https://api.slack.com/docs/formatting#how_to_escape_characters
+    '''
+    return str.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+def send_slack_message(title='', body_lines=None):
+    ''' Send a slack webhook with the passed message. Body can be a string or a list of strings; each string in the list will be shown on its own line.
     '''
     # Only send if a Slack webhook URL has been set
     webhook_url = current_app.config.get('SLACK_WEBHOOK_URL')
     if webhook_url:
+        # format the title
+        title_text = 'New Message from Comport!'
         if title:
-            title = '*{}*\n'.format(title)
-        pretext = '{title}{body}'.format(title=title, body=body)
-        payload_values = dict(text=pretext)
+            title_text = '*{}*'.format(title)
+
+        body_text = ''
+        fallback_text = ''
+        if body_lines:
+            if type(body_lines) is list:
+                body_lines = [slack_escape(line) for line in body_lines if line]
+            else:
+                body_lines = [slack_escape(body_lines)]
+            fallback_text = ', '.join(body_lines)
+            body_text = '\n'.join(body_lines)
+
+        attachment_values = dict(text=body_text, fallback=fallback_text, color="#0071bc")
+        payload_values = dict(text=title_text)
+        payload_values['attachments'] = [attachment_values]
         payload = json.dumps(payload_values)
         headers = {'Content-type': 'application/json'}
         requests.post(webhook_url, data=payload, headers=headers)

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,1 @@
+SLACK_WEBHOOK_URL={A Slack Incoming Webhook URL}

--- a/manage.py
+++ b/manage.py
@@ -28,6 +28,8 @@ if os.path.exists('.env'):
 if os.environ.get("COMPORT_ENV") == 'prod':
     config_object = ProdConfig
 else:
+    # No Slack webhook URL for testing
+    del(os.environ['SLACK_WEBHOOK_URL'])
     config_object = DevConfig
 
 # create the app

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,6 @@ from flask_script import Manager, Shell, Server, prompt_pass
 from flask_migrate import MigrateCommand, upgrade
 from comport.content.defaults import ChartBlockDefaults
 
-
 from comport.app import create_app
 from comport.user.models import User, Role
 from comport.department.models import Department, Extractor
@@ -18,16 +17,26 @@ import csv
 import hashlib
 from testclient.JSON_test_client import JSONTestClient
 
+# set environment variables from the .env file
+if os.path.exists('.env'):
+    for line in open('.env'):
+        var = [item.strip() for item in line.strip().split('=')]
+        if len(var) == 2:
+            os.environ[var[0]] = var[1]
+
+# pick a configuration object
 if os.environ.get("COMPORT_ENV") == 'prod':
-    app = create_app(ProdConfig)
+    config_object = ProdConfig
 else:
-    app = create_app(DevConfig)
+    config_object = DevConfig
+
+# create the app
+app = create_app(config_object)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 TEST_PATH = os.path.join(HERE, 'tests')
 
 manager = Manager(app)
-
 
 def _make_context():
     """Return context dict for a shell session so you can access

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@
 # Testing
 pytest>=2.6.3
 webtest
+responses==0.5.1
 
 # Management script
 Flask-Script

--- a/tests/test_interest_form.py
+++ b/tests/test_interest_form.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import pytest
+from comport.interest.forms import InterestForm
+from comport.interest.models import Interested
+
+@pytest.mark.usefixtures('app')
+class TestInterestForm:
+
+    def test_validate_success(self, db):
+        ''' The form validates when properly filled out.
+        '''
+        form = InterestForm(name="Jean Weaver", agency="Clinton Police Department", location="Clinton, OK", phone="580-970-3338", email="jean.weaver@example.com", comments="I'm interested in Comport as an open-source tool!")
+        assert form.validate() is True
+
+    def test_name_required(self):
+        ''' The form requires a non-None name.
+        '''
+        form = InterestForm(name=None, agency="Clinton Police Department", location="Clinton, OK", phone="580-970-3338", email="jean.weaver@example.com", comments="I'm interested in Comport as an open-source tool!")
+        assert form.validate() is False
+        assert 'This field is required.' in form.name.errors
+
+    def test_agency_required(self):
+        ''' The form requires a non-None agency.
+        '''
+        form = InterestForm(name="Jean Weaver", agency=None, location="Clinton, OK", phone="580-970-3338", email="jean.weaver@example.com", comments="I'm interested in Comport as an open-source tool!")
+        assert form.validate() is False
+        assert 'This field is required.' in form.agency.errors
+
+    def test_location_required(self):
+        ''' The form requires a non-None location.
+        '''
+        form = InterestForm(name="Jean Weaver", agency="Clinton Police Department", location=None, phone="580-970-3338", email="jean.weaver@example.com", comments="I'm interested in Comport as an open-source tool!")
+        assert form.validate() is False
+        assert 'This field is required.' in form.location.errors
+
+    def test_phone_required(self):
+        ''' The form requires a non-None phone.
+        '''
+        form = InterestForm(name="Jean Weaver", agency="Clinton Police Department", location="Clinton, OK", phone=None, email="jean.weaver@example.com", comments="I'm interested in Comport as an open-source tool!")
+        assert form.validate() is False
+        assert 'This field is required.' in form.phone.errors
+
+    def test_email_required(self):
+        ''' The form requires a non-None email.
+        '''
+        form = InterestForm(name="Jean Weaver", agency="Clinton Police Department", location="Clinton, OK", phone="580-970-3338", email=None, comments="I'm interested in Comport as an open-source tool!")
+        assert form.validate() is False
+        assert 'This field is required.' in form.email.errors
+
+    def test_email_valid(self):
+        ''' The form requires a valid email.
+        '''
+        form = InterestForm(name="Jean Weaver", agency="Clinton Police Department", location="Clinton, OK", phone="580-970-3338", email="jean.weaverexample.com", comments="I'm interested in Comport as an open-source tool!")
+        assert form.validate() is False
+        assert 'Invalid email address.' in form.email.errors
+
+    def test_comments_not_required(self):
+        ''' The form does not require a non-None comment.
+        '''
+        form = InterestForm(name="Jean Weaver", agency="Clinton Police Department", location="Clinton, OK", phone="580-970-3338", email="jean.weaver@example.com", comments=None)
+        assert form.validate() is True


### PR DESCRIPTION
POSTs notifications to a Slack webhook URL when an interest form is submitted or an extractor pings the heartbeat URL. The URL is included via an environment variable. Also added tests for the interest form, and tests for both notifications.

Closes #80
