### PR TITLE
Make data sets private

### DIFF
--- a/comport/decorators.py
+++ b/comport/decorators.py
@@ -20,8 +20,14 @@ def authorized_access_only(dataset=None):
                 except ValueError:
                     dataset_is_public = True
 
-            if (not department.is_public or not dataset_is_public) and not current_user.is_authenticated():
+            if current_user.is_authenticated():
+                user_has_dept_access = current_user.has_department(department.id) or current_user.is_admin()
+            else:
+                user_has_dept_access = False
+
+            if (not department.is_public or not dataset_is_public) and (not current_user.is_authenticated() or not user_has_dept_access):
                 abort(403)
+
             return view_function(*args, **kwargs)
         return decorated_function
     return check_authorized

--- a/comport/decorators.py
+++ b/comport/decorators.py
@@ -13,6 +13,8 @@ def authorized_access_only(dataset=None):
                 department = Department.query.filter_by(short_name=kwargs["short_name"].upper()).first()
             except KeyError:
                 department = Department.query.filter_by(id=kwargs["department_id"]).first()
+
+            # check whether the current dataset is public
             dataset_is_public = True
             if dataset:
                 try:
@@ -20,11 +22,13 @@ def authorized_access_only(dataset=None):
                 except ValueError:
                     dataset_is_public = True
 
+            # check whether the user has access to this department
             if current_user.is_authenticated():
                 user_has_dept_access = current_user.has_department(department.id) or current_user.is_admin()
             else:
                 user_has_dept_access = False
 
+            # abort with a 403 Forbidden if the department or dataset's not public and the user's not authorized to access it
             if (not department.is_public or not dataset_is_public) and (not current_user.is_authenticated() or not user_has_dept_access):
                 abort(403)
 

--- a/comport/department/models.py
+++ b/comport/department/models.py
@@ -22,6 +22,10 @@ class Department(SurrogatePK, Model):
     name = Column(db.String(80), unique=True, nullable=False)
     short_name = Column(db.String(80), unique=True, nullable=False)
     is_public = Column(db.Boolean, default=True, nullable=False)
+    is_public_use_of_force_incidents = Column(db.Boolean, default=True, nullable=False)
+    is_public_citizen_complaints = Column(db.Boolean, default=True, nullable=False)
+    is_public_officer_involved_shootings = Column(db.Boolean, default=True, nullable=False)
+    is_public_assaults_on_officers = Column(db.Boolean, default=True, nullable=False)
     invite_codes = relationship("Invite_Code", backref="department")
     users = relationship("User", secondary=user_department_relationship_table, backref="departments")
     use_of_force_incidents = relationship(

--- a/comport/department/views.py
+++ b/comport/department/views.py
@@ -289,7 +289,7 @@ def assaults_on_officers_schema(department_id):
 
 # <<<<<<<< DATA ENDPOINTS >>>>>>>>>>
 @blueprint.route('/<int:department_id>/uof.csv')
-@authorized_access_only()
+@authorized_access_only(dataset="use_of_force_incidents")
 def use_of_force_csv(department_id):
     department = Department.get_by_id(department_id)
     if not department:
@@ -297,7 +297,7 @@ def use_of_force_csv(department_id):
     return Response(department.get_uof_csv(), mimetype="text/csv")
 
 @blueprint.route('/<int:department_id>/complaints.csv')
-@authorized_access_only()
+@authorized_access_only(dataset="citizen_complaints")
 def complaints_csv(department_id):
     department = Department.get_by_id(department_id)
     if not department:
@@ -305,7 +305,7 @@ def complaints_csv(department_id):
     return Response(department.get_complaint_csv(), mimetype="text/csv")
 
 @blueprint.route('/<int:department_id>/assaultsonofficers.csv')
-@authorized_access_only()
+@authorized_access_only(dataset="assaults_on_officers")
 def assaults_csv(department_id):
     department = Department.get_by_id(department_id)
     if not department:
@@ -313,7 +313,7 @@ def assaults_csv(department_id):
     return Response(department.get_assaults_csv(), mimetype="text/csv")
 
 @blueprint.route('/<int:department_id>/ois.csv')
-@authorized_access_only()
+@authorized_access_only(dataset="officer_involved_shootings")
 def ois_csv(department_id):
     department = Department.get_by_id(department_id)
     if not department:
@@ -347,7 +347,7 @@ def public_intro(short_name):
     return render_template("department/site/index.html", chart_blocks=department.get_introduction_blocks(), department=department, editing=False, published=True)
 
 @blueprint.route("/<short_name>/complaints/")
-@authorized_access_only()
+@authorized_access_only(dataset="citizen_complaints")
 def public_complaints(short_name):
     department = Department.query.filter_by(short_name=short_name.upper()).first()
     if not department:
@@ -355,7 +355,7 @@ def public_complaints(short_name):
     return render_template("department/site/complaints.html", department=department, chart_blocks=department.get_complaint_blocks(), editing=False, published=True)
 
 @blueprint.route('/<short_name>/schema/complaints/')
-@authorized_access_only()
+@authorized_access_only(dataset="citizen_complaints")
 def public_complaints_schema(short_name):
     department = Department.query.filter_by(short_name=short_name.upper()).first()
     if not department:
@@ -363,7 +363,7 @@ def public_complaints_schema(short_name):
     return render_template("department/site/schema/complaints.html", department=department, published=True)
 
 @blueprint.route("/<short_name>/assaultsonofficers/")
-@authorized_access_only()
+@authorized_access_only(dataset="assaults_on_officers")
 def public_assaults(short_name):
     department = Department.query.filter_by(short_name=short_name.upper()).first()
     if not department:
@@ -371,7 +371,7 @@ def public_assaults(short_name):
     return render_template("department/site/assaults.html", department=department, chart_blocks=department.get_assaults_blocks(), editing=False, published=True)
 
 @blueprint.route('/<short_name>/schema/assaultsonofficers/')
-@authorized_access_only()
+@authorized_access_only(dataset="assaults_on_officers")
 def public_assaults_schema(short_name):
     department = Department.query.filter_by(short_name=short_name.upper()).first()
     if not department:
@@ -379,7 +379,7 @@ def public_assaults_schema(short_name):
     return render_template("department/site/schema/assaults.html", department=department, published=True)
 
 @blueprint.route("/<short_name>/useofforce/")
-@authorized_access_only()
+@authorized_access_only(dataset="use_of_force_incidents")
 def public_uof(short_name):
     department = Department.query.filter_by(short_name=short_name.upper()).first()
     if not department:
@@ -387,7 +387,7 @@ def public_uof(short_name):
     return render_template("department/site/useofforce.html", department=department, chart_blocks=department.get_uof_blocks(), editing=False, published=True)
 
 @blueprint.route("/<short_name>/officerinvolvedshootings/")
-@authorized_access_only()
+@authorized_access_only(dataset="officer_involved_shootings")
 def public_ois(short_name):
     department = Department.query.filter_by(short_name=short_name.upper()).first()
     if not department:
@@ -395,7 +395,7 @@ def public_ois(short_name):
     return render_template("department/site/ois.html", department=department, chart_blocks=department.get_ois_blocks(), editing=False, published=True)
 
 @blueprint.route('/<short_name>/schema/useofforce/')
-@authorized_access_only()
+@authorized_access_only(dataset="use_of_force_incidents")
 def public_uof_schema(short_name):
     department = Department.query.filter_by(short_name=short_name.upper()).first()
     if not department:
@@ -403,7 +403,7 @@ def public_uof_schema(short_name):
     return render_template("department/site/schema/useofforce.html", department=department, published=True)
 
 @blueprint.route('/<short_name>/schema/officerinvolvedshootings/')
-@authorized_access_only()
+@authorized_access_only(dataset="officer_involved_shootings")
 def public_ois_schema(short_name):
     department = Department.query.filter_by(short_name=short_name.upper()).first()
     if not department:

--- a/migrations/versions/0d78d545906f_.py
+++ b/migrations/versions/0d78d545906f_.py
@@ -15,10 +15,10 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.add_column('departments', sa.Column('is_public_assaults_on_officers', sa.Boolean(), nullable=False))
-    op.add_column('departments', sa.Column('is_public_citizen_complaints', sa.Boolean(), nullable=False))
-    op.add_column('departments', sa.Column('is_public_officer_involved_shootings', sa.Boolean(), nullable=False))
-    op.add_column('departments', sa.Column('is_public_use_of_force_incidents', sa.Boolean(), nullable=False))
+    op.add_column('departments', sa.Column('is_public_assaults_on_officers', sa.Boolean(), server_default=sa.true(), nullable=False))
+    op.add_column('departments', sa.Column('is_public_citizen_complaints', sa.Boolean(), server_default=sa.true(), nullable=False))
+    op.add_column('departments', sa.Column('is_public_officer_involved_shootings', sa.Boolean(), server_default=sa.true(), nullable=False))
+    op.add_column('departments', sa.Column('is_public_use_of_force_incidents', sa.Boolean(), server_default=sa.true(), nullable=False))
 
 
 def downgrade():

--- a/migrations/versions/0d78d545906f_.py
+++ b/migrations/versions/0d78d545906f_.py
@@ -1,0 +1,28 @@
+"""Add 'is_public' flags for datasets
+
+Revision ID: 0d78d545906f
+Revises: 6d30846080b2
+Create Date: 2016-06-27 15:30:14.415519
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0d78d545906f'
+down_revision = '6d30846080b2'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('departments', sa.Column('is_public_assaults_on_officers', sa.Boolean(), nullable=False))
+    op.add_column('departments', sa.Column('is_public_citizen_complaints', sa.Boolean(), nullable=False))
+    op.add_column('departments', sa.Column('is_public_officer_involved_shootings', sa.Boolean(), nullable=False))
+    op.add_column('departments', sa.Column('is_public_use_of_force_incidents', sa.Boolean(), nullable=False))
+
+
+def downgrade():
+    op.drop_column('departments', 'is_public_use_of_force_incidents')
+    op.drop_column('departments', 'is_public_officer_involved_shootings')
+    op.drop_column('departments', 'is_public_citizen_complaints')
+    op.drop_column('departments', 'is_public_assaults_on_officers')

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -227,6 +227,34 @@ class TestConditionalAccess:
         testapp.get("/department/{}/schema/assaultsonofficers/".format(department.short_name), status=200)
         testapp.get("/department/{}/assaultsonofficers.csv".format(department.id), status=200)
 
+    def test_only_department_user_can_access_non_public_datasets(self, testapp, preconfigured_department):
+        # create a department
+        department, _ = preconfigured_department
+        department.is_public_citizen_complaints = False
+        department.is_public_use_of_force_incidents = False
+        department.is_public_officer_involved_shootings = False
+        department.is_public_assaults_on_officers = False
+
+        # log in under a different department, datasets should not be accessible
+        bad_department = Department.create(name="Bad Police Department", short_name="BPD", load_defaults=False)
+        log_in_user(testapp, bad_department)
+
+        testapp.get("/department/{}/complaints/".format(department.short_name), status=403)
+        testapp.get("/department/{}/schema/complaints/".format(department.short_name), status=403)
+        testapp.get("/department/{}/complaints.csv".format(department.id), status=403)
+
+        testapp.get("/department/{}/useofforce/".format(department.short_name), status=403)
+        testapp.get("/department/{}/schema/useofforce/".format(department.short_name), status=403)
+        testapp.get("/department/{}/uof.csv".format(department.id), status=403)
+
+        testapp.get("/department/{}/officerinvolvedshootings/".format(department.short_name), status=403)
+        testapp.get("/department/{}/schema/officerinvolvedshootings/".format(department.short_name), status=403)
+        testapp.get("/department/{}/ois.csv".format(department.id), status=403)
+
+        testapp.get("/department/{}/assaultsonofficers/".format(department.short_name), status=403)
+        testapp.get("/department/{}/schema/assaultsonofficers/".format(department.short_name), status=403)
+        testapp.get("/department/{}/assaultsonofficers.csv".format(department.id), status=403)
+
 @pytest.mark.usefixtures('db')
 class TestPagesRespond:
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -144,21 +144,6 @@ class TestConditionalAccess:
         testapp.get("/department/{}/ois.csv".format(department.id), status=200)
         testapp.get("/department/{}/assaultsonofficers.csv".format(department.id), status=200)
 
-@pytest.mark.usefixtures('db')
-class TestPagesRespond:
-
-    def test_complaints_schema_preview_page_exists(self, testapp):
-        # create a department
-        department = Department.create(name="Spleen Police Department", short_name="SPD", load_defaults=False)
-
-        # set up a user
-        log_in_user(testapp, department)
-
-        # make a resquest to specific front page
-        response = testapp.get("/department/{}/preview/schema/complaints".format(department.id))
-
-        assert response.status_code == 200
-
     def test_can_change_dataset_public(self):
         # create a department
         department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
@@ -188,6 +173,21 @@ class TestPagesRespond:
 
         assert response.status_code == 200
         assert 'You do not have sufficient permissions to do that' in response
+
+@pytest.mark.usefixtures('db')
+class TestPagesRespond:
+
+    def test_complaints_schema_preview_page_exists(self, testapp):
+        # create a department
+        department = Department.create(name="Spleen Police Department", short_name="SPD", load_defaults=False)
+
+        # set up a user
+        log_in_user(testapp, department)
+
+        # make a resquest to specific front page
+        response = testapp.get("/department/{}/preview/schema/complaints".format(department.id))
+
+        assert response.status_code == 200
 
     def test_loading_unconfigured_data_type_redirects_to_index(self, testapp):
         # create a department

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -121,6 +121,8 @@ class TestConditionalAccess:
         testapp.get("/department/{}/uof.csv".format(department.id), status=403)
         testapp.get("/department/{}/ois.csv".format(department.id), status=403)
         testapp.get("/department/{}/assaultsonofficers.csv".format(department.id), status=403)
+        testapp.get("/department/{}/officerCalls.csv".format(department.id), status=403)
+        testapp.get("/department/{}/demographics.csv".format(department.id), status=403)
 
     def test_department_logged_in_authorized(self, testapp, preconfigured_department):
         # set up department
@@ -143,8 +145,22 @@ class TestConditionalAccess:
         testapp.get("/department/{}/uof.csv".format(department.id), status=200)
         testapp.get("/department/{}/ois.csv".format(department.id), status=200)
         testapp.get("/department/{}/assaultsonofficers.csv".format(department.id), status=200)
+        testapp.get("/department/{}/officerCalls.csv".format(department.id), status=200)
+        testapp.get("/department/{}/demographics.csv".format(department.id), status=200)
 
-    def test_can_change_dataset_public(self):
+    def test_datset_is_public_by_default(self):
+        # create a department
+        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        assert hasattr(department, "is_public_assaults_on_officers")
+        assert hasattr(department, "is_public_officer_involved_shootings")
+        assert hasattr(department, "is_public_citizen_complaints")
+        assert hasattr(department, "is_public_use_of_force_incidents")
+        assert department.is_public_assaults_on_officers is True
+        assert department.is_public_officer_involved_shootings is True
+        assert department.is_public_citizen_complaints is True
+        assert department.is_public_use_of_force_incidents is True
+
+    def test_dataset_can_be_set_private(self):
         # create a department
         department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
         assert hasattr(department, "is_public_assaults_on_officers")
@@ -265,7 +281,7 @@ class TestPagesRespond:
         # set up a user
         log_in_user(testapp, department)
 
-        # make a resquest to specific front page
+        # make a request to specific front page
         response = testapp.get("/department/{}/preview/schema/complaints".format(department.id))
 
         assert response.status_code == 200
@@ -294,7 +310,7 @@ class TestPagesRespond:
         # create a department
         Department.create(name="Spleen Police Department", short_name="SPD", load_defaults=False)
 
-        # make a resquest to specific front page
+        # make a request to specific front page
         response = testapp.get("/department/SPD/schema/assaultsonofficers/")
 
         assert response.status_code == 200
@@ -306,8 +322,26 @@ class TestPagesRespond:
         # set up a user
         log_in_user(testapp, department)
 
-        # make a resquest to specific front page
+        # make a request to specific front page
         response = testapp.get("/department/{}/preview/schema/assaultsonofficers".format(department.id))
+
+        assert response.status_code == 200
+
+    def test_demographics_csv_endpoint_exists(self, testapp):
+        # create a department
+        department = Department.create(name="Spleen Police Department", short_name="SPD", load_defaults=False)
+
+        # make a request to specific front page
+        response = testapp.get("/department/{}/demographics.csv".format(department.id))
+
+        assert response.status_code == 200
+
+    def test_officer_calls_csv_endpoint_exists(self, testapp):
+        # create a department
+        department = Department.create(name="Spleen Police Department", short_name="SPD", load_defaults=False)
+
+        # make a request to specific front page
+        response = testapp.get("/department/{}/officerCalls.csv".format(department.id))
 
         assert response.status_code == 200
 
@@ -315,7 +349,7 @@ class TestPagesRespond:
         # create a department
         department = Department.create(name="Spleen Police Department", short_name="SPD", load_defaults=False)
 
-        # make a resquest to specific front page
+        # make a request to specific front page
         response = testapp.get("/department/{}/assaultsonofficers.csv".format(department.id))
 
         assert response.status_code == 200
@@ -344,7 +378,7 @@ class TestPagesRespond:
         # set up a user
         log_in_user(testapp, department)
 
-        # make a resquest to specific front page
+        # make a request to specific front page
         response = testapp.get("/department/{}/edit/assaultsonofficers".format(department.id))
 
         assert response.status_code == 200

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -164,13 +164,68 @@ class TestConditionalAccess:
     def test_visit_private_dataset_throws_unauth(self, testapp, preconfigured_department):
         # create a department
         department, _ = preconfigured_department
-        department.is_public_assaults_on_officers = False
 
         # we can access all the datasets except assaults
         testapp.get("/department/{}/complaints/".format(department.short_name), status=200)
+        testapp.get("/department/{}/schema/complaints/".format(department.short_name), status=200)
+        testapp.get("/department/{}/complaints.csv".format(department.id), status=200)
+
         testapp.get("/department/{}/useofforce/".format(department.short_name), status=200)
+        testapp.get("/department/{}/schema/useofforce/".format(department.short_name), status=200)
+        testapp.get("/department/{}/uof.csv".format(department.id), status=200)
+
         testapp.get("/department/{}/officerinvolvedshootings/".format(department.short_name), status=200)
+        testapp.get("/department/{}/schema/officerinvolvedshootings/".format(department.short_name), status=200)
+        testapp.get("/department/{}/ois.csv".format(department.id), status=200)
+
+        testapp.get("/department/{}/assaultsonofficers/".format(department.short_name), status=200)
+        testapp.get("/department/{}/schema/assaultsonofficers/".format(department.short_name), status=200)
+        testapp.get("/department/{}/assaultsonofficers.csv".format(department.id), status=200)
+
+        # set each dataset is_public to false, and verify that they're no longer accessible
+
+        department.is_public_citizen_complaints = False
+
+        testapp.get("/department/{}/complaints/".format(department.short_name), status=403)
+        testapp.get("/department/{}/schema/complaints/".format(department.short_name), status=403)
+        testapp.get("/department/{}/complaints.csv".format(department.id), status=403)
+
+        department.is_public_use_of_force_incidents = False
+
+        testapp.get("/department/{}/useofforce/".format(department.short_name), status=403)
+        testapp.get("/department/{}/schema/useofforce/".format(department.short_name), status=403)
+        testapp.get("/department/{}/uof.csv".format(department.id), status=403)
+
+        department.is_public_officer_involved_shootings = False
+
+        testapp.get("/department/{}/officerinvolvedshootings/".format(department.short_name), status=403)
+        testapp.get("/department/{}/schema/officerinvolvedshootings/".format(department.short_name), status=403)
+        testapp.get("/department/{}/ois.csv".format(department.id), status=403)
+
+        department.is_public_assaults_on_officers = False
+
         testapp.get("/department/{}/assaultsonofficers/".format(department.short_name), status=403)
+        testapp.get("/department/{}/schema/assaultsonofficers/".format(department.short_name), status=403)
+        testapp.get("/department/{}/assaultsonofficers.csv".format(department.id), status=403)
+
+        # log in, try again, and they should all be accessible again
+        log_in_user(testapp, department)
+
+        testapp.get("/department/{}/complaints/".format(department.short_name), status=200)
+        testapp.get("/department/{}/schema/complaints/".format(department.short_name), status=200)
+        testapp.get("/department/{}/complaints.csv".format(department.id), status=200)
+
+        testapp.get("/department/{}/useofforce/".format(department.short_name), status=200)
+        testapp.get("/department/{}/schema/useofforce/".format(department.short_name), status=200)
+        testapp.get("/department/{}/uof.csv".format(department.id), status=200)
+
+        testapp.get("/department/{}/officerinvolvedshootings/".format(department.short_name), status=200)
+        testapp.get("/department/{}/schema/officerinvolvedshootings/".format(department.short_name), status=200)
+        testapp.get("/department/{}/ois.csv".format(department.id), status=200)
+
+        testapp.get("/department/{}/assaultsonofficers/".format(department.short_name), status=200)
+        testapp.get("/department/{}/schema/assaultsonofficers/".format(department.short_name), status=200)
+        testapp.get("/department/{}/assaultsonofficers.csv".format(department.id), status=200)
 
 @pytest.mark.usefixtures('db')
 class TestPagesRespond:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -166,13 +166,11 @@ class TestConditionalAccess:
         department, _ = preconfigured_department
         department.is_public_assaults_on_officers = False
 
-        response = testapp.get("/department/{}/assaultsonofficers/".format(department.short_name), status=302)
-
-        assert response.status_code == 302
-        response = response.follow()
-
-        assert response.status_code == 200
-        assert 'You do not have sufficient permissions to do that' in response
+        # we can access all the datasets except assaults
+        testapp.get("/department/{}/complaints/".format(department.short_name), status=200)
+        testapp.get("/department/{}/useofforce/".format(department.short_name), status=200)
+        testapp.get("/department/{}/officerinvolvedshootings/".format(department.short_name), status=200)
+        testapp.get("/department/{}/assaultsonofficers/".format(department.short_name), status=403)
 
 @pytest.mark.usefixtures('db')
 class TestPagesRespond:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -176,6 +176,19 @@ class TestPagesRespond:
         assert department.is_public_citizen_complaints is False
         assert department.is_public_use_of_force_incidents is False
 
+    def test_visit_private_dataset_throws_unauth(self, testapp, preconfigured_department):
+        # create a department
+        department, _ = preconfigured_department
+        department.is_public_assaults_on_officers = False
+
+        response = testapp.get("/department/{}/assaultsonofficers/".format(department.short_name), status=302)
+
+        assert response.status_code == 302
+        response = response.follow()
+
+        assert response.status_code == 200
+        assert 'You do not have sufficient permissions to do that' in response
+
     def test_loading_unconfigured_data_type_redirects_to_index(self, testapp):
         # create a department
         department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -159,6 +159,23 @@ class TestPagesRespond:
 
         assert response.status_code == 200
 
+    def test_can_change_dataset_public(self):
+        # create a department
+        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        assert hasattr(department, "is_public_assaults_on_officers")
+        assert hasattr(department, "is_public_officer_involved_shootings")
+        assert hasattr(department, "is_public_citizen_complaints")
+        assert hasattr(department, "is_public_use_of_force_incidents")
+        department.is_public_assaults_on_officers = False
+        department.is_public_officer_involved_shootings = False
+        department.is_public_citizen_complaints = False
+        department.is_public_use_of_force_incidents = False
+        department.save()
+        assert department.is_public_assaults_on_officers is False
+        assert department.is_public_officer_involved_shootings is False
+        assert department.is_public_citizen_complaints is False
+        assert department.is_public_use_of_force_incidents is False
+
     def test_loading_unconfigured_data_type_redirects_to_index(self, testapp):
         # create a department
         department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)


### PR DESCRIPTION
Data sets can now be set private; only logged-in users with access to the related department or admin users will be able to see them.

Closes #102
