### PR TITLE
navigation links on preview pages

### DIFF
--- a/comport/department/views.py
+++ b/comport/department/views.py
@@ -202,7 +202,7 @@ def preview_ois(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/ois.html", department=department, chart_blocks=department.get_ois_blocks(), editing=False)
+    return render_template("department/site/ois.html", department=department, chart_blocks=department.get_ois_blocks(), editing=False, preview_mode=True, endpoint_name="ois")
 
 @blueprint.route("/<int:department_id>/preview/useofforce")
 @login_required
@@ -211,7 +211,7 @@ def preview_use_of_force(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/useofforce.html", department=department, chart_blocks=department.get_uof_blocks(), editing=False)
+    return render_template("department/site/useofforce.html", department=department, chart_blocks=department.get_uof_blocks(), editing=False, preview_mode=True, endpoint_name="useofforce")
 
 @blueprint.route("/<int:department_id>/preview/complaints")
 @login_required
@@ -220,7 +220,7 @@ def preview_complaints(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/complaints.html", department=department, chart_blocks=department.get_complaint_blocks(), editing=False)
+    return render_template("department/site/complaints.html", department=department, chart_blocks=department.get_complaint_blocks(), editing=False, preview_mode=True, endpoint_name="complaints")
 
 @blueprint.route("/<int:department_id>/preview/assaultsonofficers")
 @login_required
@@ -229,7 +229,7 @@ def preview_assaults(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/assaults.html", department=department, chart_blocks=department.get_assaults_blocks(), editing=False)
+    return render_template("department/site/assaults.html", department=department, chart_blocks=department.get_assaults_blocks(), editing=False, preview_mode=True, endpoint_name="assaultsonofficers")
 
 @blueprint.route("/<int:department_id>/preview/index")
 @login_required
@@ -238,7 +238,7 @@ def preview_index(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/index.html", chart_blocks=department.get_introduction_blocks(), department=department, editing=False)
+    return render_template("department/site/index.html", chart_blocks=department.get_introduction_blocks(), department=department, editing=False, preview_mode=True, endpoint_name="index")
 
 
 # <<<<<<<< SCHEMA ENDPOINTS >>>>>>>>>>
@@ -249,7 +249,7 @@ def complaints_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks())
+    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks(), editing=False, preview_mode=True, endpoint_name="complaints")
 
 @blueprint.route('/<int:department_id>/edit/schema/complaints')
 @login_required
@@ -258,7 +258,7 @@ def complaints_schema_edit(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks(), editing=True)
+    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks(), editing=True,)
 
 @blueprint.route('/<int:department_id>/preview/schema/useofforce')
 @login_required
@@ -267,7 +267,7 @@ def useofforce_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/useofforce.html", department=department, chart_blocks=department.get_uof_schema_blocks())
+    return render_template("department/site/schema/useofforce.html", department=department, chart_blocks=department.get_uof_schema_blocks(), editing=False, preview_mode=True, endpoint_name="useofforce")
 
 @blueprint.route('/<int:department_id>/edit/schema/useofforce')
 @login_required
@@ -294,7 +294,8 @@ def ois_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/ois.html", department=department, chart_blocks=department.get_ois_schema_blocks(), editing=False)
+    return render_template("department/site/schema/ois.html", department=department, chart_blocks=department.get_ois_schema_blocks(), editing=False,preview_mode=True, endpoint_name="ois")
+
 
 @blueprint.route('/<int:department_id>/preview/schema/assaultsonofficers')
 @login_required
@@ -303,7 +304,8 @@ def assaults_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/assaults.html", department=department, chart_blocks=department.get_assaults_schema_blocks())
+    return render_template("department/site/schema/assaults.html", department=department, chart_blocks=department.get_assaults_schema_blocks(), editing=False, preview_mode=True, endpoint_name="assaultsonofficers")
+
 
 @blueprint.route('/<int:department_id>/edit/schema/assaultsonofficers')
 @login_required

--- a/comport/department/views.py
+++ b/comport/department/views.py
@@ -202,7 +202,7 @@ def preview_ois(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/ois.html", department=department, chart_blocks=department.get_ois_blocks(), editing=False, preview_mode=True, endpoint_name="ois")
+    return render_template("department/site/ois.html", department=department, chart_blocks=department.get_ois_blocks(), editing=False, preview_mode=True)
 
 @blueprint.route("/<int:department_id>/preview/useofforce")
 @login_required
@@ -211,7 +211,7 @@ def preview_use_of_force(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/useofforce.html", department=department, chart_blocks=department.get_uof_blocks(), editing=False, preview_mode=True, endpoint_name="useofforce")
+    return render_template("department/site/useofforce.html", department=department, chart_blocks=department.get_uof_blocks(), editing=False, preview_mode=True)
 
 @blueprint.route("/<int:department_id>/preview/complaints")
 @login_required
@@ -220,7 +220,7 @@ def preview_complaints(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/complaints.html", department=department, chart_blocks=department.get_complaint_blocks(), editing=False, preview_mode=True, endpoint_name="complaints")
+    return render_template("department/site/complaints.html", department=department, chart_blocks=department.get_complaint_blocks(), editing=False, preview_mode=True)
 
 @blueprint.route("/<int:department_id>/preview/assaultsonofficers")
 @login_required
@@ -229,7 +229,7 @@ def preview_assaults(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/assaults.html", department=department, chart_blocks=department.get_assaults_blocks(), editing=False, preview_mode=True, endpoint_name="assaultsonofficers")
+    return render_template("department/site/assaults.html", department=department, chart_blocks=department.get_assaults_blocks(), editing=False, preview_mode=True)
 
 @blueprint.route("/<int:department_id>/preview/index")
 @login_required
@@ -238,7 +238,7 @@ def preview_index(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/index.html", chart_blocks=department.get_introduction_blocks(), department=department, editing=False, preview_mode=True, endpoint_name="index")
+    return render_template("department/site/index.html", chart_blocks=department.get_introduction_blocks(), department=department, editing=False, preview_mode=True)
 
 
 # <<<<<<<< SCHEMA ENDPOINTS >>>>>>>>>>
@@ -249,7 +249,7 @@ def complaints_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks(), editing=False, preview_mode=True, endpoint_name="complaints")
+    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks(), editing=False, preview_mode=True)
 
 @blueprint.route('/<int:department_id>/edit/schema/complaints')
 @login_required
@@ -267,7 +267,7 @@ def useofforce_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/useofforce.html", department=department, chart_blocks=department.get_uof_schema_blocks(), editing=False, preview_mode=True, endpoint_name="useofforce")
+    return render_template("department/site/schema/useofforce.html", department=department, chart_blocks=department.get_uof_schema_blocks(), editing=False, preview_mode=True)
 
 @blueprint.route('/<int:department_id>/edit/schema/useofforce')
 @login_required
@@ -294,7 +294,7 @@ def ois_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/ois.html", department=department, chart_blocks=department.get_ois_schema_blocks(), editing=False,preview_mode=True, endpoint_name="ois")
+    return render_template("department/site/schema/ois.html", department=department, chart_blocks=department.get_ois_schema_blocks(), editing=False, preview_mode=True)
 
 
 @blueprint.route('/<int:department_id>/preview/schema/assaultsonofficers')
@@ -304,7 +304,7 @@ def assaults_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/assaults.html", department=department, chart_blocks=department.get_assaults_schema_blocks(), editing=False, preview_mode=True, endpoint_name="assaultsonofficers")
+    return render_template("department/site/schema/assaults.html", department=department, chart_blocks=department.get_assaults_schema_blocks(), editing=False, preview_mode=True)
 
 
 @blueprint.route('/<int:department_id>/edit/schema/assaultsonofficers')

--- a/comport/department/views.py
+++ b/comport/department/views.py
@@ -258,7 +258,7 @@ def complaints_schema_edit(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks(), editing=True,)
+    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks(), editing=True)
 
 @blueprint.route('/<int:department_id>/preview/schema/useofforce')
 @login_required
@@ -296,7 +296,6 @@ def ois_schema_preview(department_id):
         abort(404)
     return render_template("department/site/schema/ois.html", department=department, chart_blocks=department.get_ois_schema_blocks(), editing=False)
 
-
 @blueprint.route('/<int:department_id>/preview/schema/assaultsonofficers')
 @login_required
 @admin_or_department_required()
@@ -305,7 +304,6 @@ def assaults_schema_preview(department_id):
     if not department:
         abort(404)
     return render_template("department/site/schema/assaults.html", department=department, chart_blocks=department.get_assaults_schema_blocks(), editing=False)
-
 
 @blueprint.route('/<int:department_id>/edit/schema/assaultsonofficers')
 @login_required

--- a/comport/department/views.py
+++ b/comport/department/views.py
@@ -202,7 +202,7 @@ def preview_ois(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/ois.html", department=department, chart_blocks=department.get_ois_blocks(), editing=False, preview_mode=True)
+    return render_template("department/site/ois.html", department=department, chart_blocks=department.get_ois_blocks(), editing=False)
 
 @blueprint.route("/<int:department_id>/preview/useofforce")
 @login_required
@@ -211,7 +211,7 @@ def preview_use_of_force(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/useofforce.html", department=department, chart_blocks=department.get_uof_blocks(), editing=False, preview_mode=True)
+    return render_template("department/site/useofforce.html", department=department, chart_blocks=department.get_uof_blocks(), editing=False)
 
 @blueprint.route("/<int:department_id>/preview/complaints")
 @login_required
@@ -220,7 +220,7 @@ def preview_complaints(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/complaints.html", department=department, chart_blocks=department.get_complaint_blocks(), editing=False, preview_mode=True)
+    return render_template("department/site/complaints.html", department=department, chart_blocks=department.get_complaint_blocks(), editing=False)
 
 @blueprint.route("/<int:department_id>/preview/assaultsonofficers")
 @login_required
@@ -229,7 +229,7 @@ def preview_assaults(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/assaults.html", department=department, chart_blocks=department.get_assaults_blocks(), editing=False, preview_mode=True)
+    return render_template("department/site/assaults.html", department=department, chart_blocks=department.get_assaults_blocks(), editing=False)
 
 @blueprint.route("/<int:department_id>/preview/index")
 @login_required
@@ -238,7 +238,7 @@ def preview_index(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/index.html", chart_blocks=department.get_introduction_blocks(), department=department, editing=False, preview_mode=True)
+    return render_template("department/site/index.html", chart_blocks=department.get_introduction_blocks(), department=department, editing=False)
 
 
 # <<<<<<<< SCHEMA ENDPOINTS >>>>>>>>>>
@@ -249,7 +249,7 @@ def complaints_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks(), editing=False, preview_mode=True)
+    return render_template("department/site/schema/complaints.html", department=department, chart_blocks=department.get_complaint_schema_blocks(), editing=False)
 
 @blueprint.route('/<int:department_id>/edit/schema/complaints')
 @login_required
@@ -267,7 +267,7 @@ def useofforce_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/useofforce.html", department=department, chart_blocks=department.get_uof_schema_blocks(), editing=False, preview_mode=True)
+    return render_template("department/site/schema/useofforce.html", department=department, chart_blocks=department.get_uof_schema_blocks(), editing=False)
 
 @blueprint.route('/<int:department_id>/edit/schema/useofforce')
 @login_required
@@ -294,7 +294,7 @@ def ois_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/ois.html", department=department, chart_blocks=department.get_ois_schema_blocks(), editing=False, preview_mode=True)
+    return render_template("department/site/schema/ois.html", department=department, chart_blocks=department.get_ois_schema_blocks(), editing=False)
 
 
 @blueprint.route('/<int:department_id>/preview/schema/assaultsonofficers')
@@ -304,7 +304,7 @@ def assaults_schema_preview(department_id):
     department = Department.get_by_id(department_id)
     if not department:
         abort(404)
-    return render_template("department/site/schema/assaults.html", department=department, chart_blocks=department.get_assaults_schema_blocks(), editing=False, preview_mode=True)
+    return render_template("department/site/schema/assaults.html", department=department, chart_blocks=department.get_assaults_schema_blocks(), editing=False)
 
 
 @blueprint.route('/<int:department_id>/edit/schema/assaultsonofficers')

--- a/comport/static/css/style.css
+++ b/comport/static/css/style.css
@@ -234,6 +234,14 @@ button:active {
           box-sizing: border-box;
 }
 
+/* Admin Edit */
+.admin_edit_btn {
+  text-align: center;
+}
+.admin_edit_btn a {
+  color: #fff;
+}
+
 /* footer */
 
 footer {

--- a/comport/templates/department/site/index.html
+++ b/comport/templates/department/site/index.html
@@ -5,6 +5,15 @@
 {% endblock css %}
 
 {% block content %}
+{% if preview_mode %} 
+{% block edit_nav %}
+  <div class="admin_edit_btn">
+    <a href="/department/{{department.id}}/edit/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
+    <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
+  </div>
+{% endblock edit_nav %}
+
+{% endif %}
 <div class="row">
   <div class="col-md-10 col-md-offset-1">
     <h1>{{department.name}}</h1>

--- a/comport/templates/department/site/index.html
+++ b/comport/templates/department/site/index.html
@@ -5,6 +5,7 @@
 {% endblock css %}
 
 {% block content %}
+{% set preview_mode = ('/preview/' in request.path) %}
 {% if preview_mode %} 
 {% block edit_nav %}
   <div class="admin_edit_btn">

--- a/comport/templates/department/site/index.html
+++ b/comport/templates/department/site/index.html
@@ -8,6 +8,7 @@
 {% if preview_mode %} 
 {% block edit_nav %}
   <div class="admin_edit_btn">
+    {% set endpoint_name = request.path.split('/')[-1] %}
     <a href="/department/{{department.id}}/edit/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
     <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
   </div>

--- a/comport/templates/department/site/public_dataset_base.html
+++ b/comport/templates/department/site/public_dataset_base.html
@@ -8,6 +8,7 @@
 {% endblock css %}
 
 {% block content %}
+{% set preview_mode = ('/preview/' in request.path) %}
 {% if preview_mode %}	
 {% block edit_nav %}
   <div class="admin_edit_btn">

--- a/comport/templates/department/site/public_dataset_base.html
+++ b/comport/templates/department/site/public_dataset_base.html
@@ -8,6 +8,16 @@
 {% endblock css %}
 
 {% block content %}
+{% if preview_mode %}	
+{% block edit_nav %}
+  <div class="admin_edit_btn">
+    <a href="/department/{{department.id}}/edit/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
+    <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
+  </div>
+{% endblock edit_nav %}
+
+{% endif %}
+
   <div class="row">
     <h1 class="col-xs-12">{{department.name}}</h1>
   </div>

--- a/comport/templates/department/site/public_dataset_base.html
+++ b/comport/templates/department/site/public_dataset_base.html
@@ -11,6 +11,7 @@
 {% if preview_mode %}	
 {% block edit_nav %}
   <div class="admin_edit_btn">
+    {% set endpoint_name = request.path.split('/')[-1] %}
     <a href="/department/{{department.id}}/edit/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
     <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
   </div>

--- a/comport/templates/department/site/schema/assaults.html
+++ b/comport/templates/department/site/schema/assaults.html
@@ -1,7 +1,12 @@
 {% extends "layout.html" %}
 
 {% block content %}
-
+{% if preview_mode %} 
+  <div class="admin_edit_btn">
+    <a href="/department/{{department.id}}/edit/schema/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
+    <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
+  </div>
+{% endif %}
 <div class="row">
   <div class="col-md-12 schema-wrapper">
     <div class="schema-header">

--- a/comport/templates/department/site/schema/assaults.html
+++ b/comport/templates/department/site/schema/assaults.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 
 {% block content %}
+{% set preview_mode = ('/preview/' in request.path) %}
 {% if preview_mode %} 
   <div class="admin_edit_btn">
     {% set endpoint_name = request.path.split('/')[-1] %}

--- a/comport/templates/department/site/schema/assaults.html
+++ b/comport/templates/department/site/schema/assaults.html
@@ -3,6 +3,7 @@
 {% block content %}
 {% if preview_mode %} 
   <div class="admin_edit_btn">
+    {% set endpoint_name = request.path.split('/')[-1] %}
     <a href="/department/{{department.id}}/edit/schema/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
     <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
   </div>

--- a/comport/templates/department/site/schema/complaints.html
+++ b/comport/templates/department/site/schema/complaints.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 
 {% block content %}
+{% set preview_mode = ('/preview/' in request.path) %}
 {% if preview_mode %} 
   <div class="admin_edit_btn">
     {% set endpoint_name = request.path.split('/')[-1] %}

--- a/comport/templates/department/site/schema/complaints.html
+++ b/comport/templates/department/site/schema/complaints.html
@@ -1,6 +1,12 @@
 {% extends "layout.html" %}
 
 {% block content %}
+{% if preview_mode %} 
+  <div class="admin_edit_btn">
+    <a href="/department/{{department.id}}/edit/schema/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
+    <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
+  </div>
+{% endif %}
 
 <div class="row">
   <div class="col-md-12 schema-wrapper">

--- a/comport/templates/department/site/schema/complaints.html
+++ b/comport/templates/department/site/schema/complaints.html
@@ -3,6 +3,7 @@
 {% block content %}
 {% if preview_mode %} 
   <div class="admin_edit_btn">
+    {% set endpoint_name = request.path.split('/')[-1] %}
     <a href="/department/{{department.id}}/edit/schema/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
     <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
   </div>

--- a/comport/templates/department/site/schema/ois.html
+++ b/comport/templates/department/site/schema/ois.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 
 {% block content %}
+{% set preview_mode = ('/preview/' in request.path) %}
 {% if preview_mode %} 
   <div class="admin_edit_btn">
     {% set endpoint_name = request.path.split('/')[-1] %}

--- a/comport/templates/department/site/schema/ois.html
+++ b/comport/templates/department/site/schema/ois.html
@@ -1,6 +1,12 @@
 {% extends "layout.html" %}
 
 {% block content %}
+{% if preview_mode %} 
+  <div class="admin_edit_btn">
+    <a href="/department/{{department.id}}/edit/schema/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
+    <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
+  </div>
+{% endif %}
 
 <div class="row">
   <div class="col-md-12 schema-wrapper">

--- a/comport/templates/department/site/schema/ois.html
+++ b/comport/templates/department/site/schema/ois.html
@@ -3,6 +3,7 @@
 {% block content %}
 {% if preview_mode %} 
   <div class="admin_edit_btn">
+    {% set endpoint_name = request.path.split('/')[-1] %}
     <a href="/department/{{department.id}}/edit/schema/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
     <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
   </div>

--- a/comport/templates/department/site/schema/useofforce.html
+++ b/comport/templates/department/site/schema/useofforce.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 
 {% block content %}
+{% set preview_mode = ('/preview/' in request.path) %}
 {% if preview_mode %} 
   <div class="admin_edit_btn">
     {% set endpoint_name = request.path.split('/')[-1] %}

--- a/comport/templates/department/site/schema/useofforce.html
+++ b/comport/templates/department/site/schema/useofforce.html
@@ -1,6 +1,12 @@
 {% extends "layout.html" %}
 
 {% block content %}
+{% if preview_mode %} 
+  <div class="admin_edit_btn">
+    <a href="/department/{{department.id}}/edit/schema/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
+    <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
+  </div>
+{% endif %}
 
 <div class="row">
   <div class="col-md-12 schema-wrapper">

--- a/comport/templates/department/site/schema/useofforce.html
+++ b/comport/templates/department/site/schema/useofforce.html
@@ -3,6 +3,7 @@
 {% block content %}
 {% if preview_mode %} 
   <div class="admin_edit_btn">
+    {% set endpoint_name = request.path.split('/')[-1] %}
     <a href="/department/{{department.id}}/edit/schema/{{endpoint_name}}" title="Edit"><button type="">Edit</button></a>
     <a href="/department/{{department.id}}" title="Done"><button type="">Done</button></a>
   </div>

--- a/comport/templates/department/site/useofforce.html
+++ b/comport/templates/department/site/useofforce.html
@@ -5,6 +5,7 @@
 <div class="row">
 
   <div class="col-xs-12 col-sm-5">
+  
     <h2>Use of Force</h2>
 
     {% if not editing %}

--- a/tests/test_admin_forms.py
+++ b/tests/test_admin_forms.py
@@ -121,6 +121,21 @@ class TestAdminEditForms:
         assert soup.find("a", href="{}/edit/schema/ois".format(department.id)) is not None
         assert soup.find("a", href="{}/edit/schema/assaultsonofficers".format(department.id)) is not None
 
+    def test_edit_and_preview_links_on_preview_page(self, testapp):
+        department = Department.create(name="Metropolis Police Department", short_name="MPD", load_defaults=True)
+
+        # set up a user
+        log_in_user(testapp, department)
+
+        # make a request to specific front page
+        for page in ['index', 'complaints', 'useofforce', 'ois', 'assaultsonofficers']:
+
+            response = testapp.get("/department/{}/preview/{}".format(department.id, page))
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.text)
+            assert soup.find("a", href="/department/{}/edit/{}".format(department.id, page)) is not None
+            assert soup.find("a", href="/department/{}".format(department.id)) is not None
+
     def test_ois_schema_edit_forms_exist(self, testapp):
         ''' Edit forms exist for the complaints schema page.
         '''
@@ -524,3 +539,19 @@ class TestAdminEditForms:
         # the location of the redirect should be the preview page
         parsed = urlparse(response.location)
         assert parsed.path == "/department/{}/preview/schema/complaints".format(department.id)
+
+
+    def test_edit_and_preview_links_on_schema_preview_page(self, testapp):
+        department = Department.create(name="Metropolis Police Department", short_name="MPD", load_defaults=True)
+
+        # set up a user
+        log_in_user(testapp, department)
+
+        # make a request to specific front page
+        for page in ['complaints', 'useofforce', 'ois', 'assaultsonofficers']:
+
+            response = testapp.get("/department/{}/preview/schema/{}".format(department.id, page))
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.text)
+            assert soup.find("a", href="/department/{}/edit/schema/{}".format(department.id, page)) is not None
+            assert soup.find("a", href="/department/{}".format(department.id)) is not None


### PR DESCRIPTION
Add 'edit' and 'done' button to all the data chart and schema preview pages. 
- edit button links back to the previous edit page
- done button links to the admin editing homepage. 