### PR TITLE
Handle missing chart blocks

### DIFF
--- a/comport/department/models.py
+++ b/comport/department/models.py
@@ -157,7 +157,8 @@ class Department(SurrogatePK, Model):
         try:
             next_block = next(b for b in self.chart_blocks if b.slug == slug)
         except StopIteration:
-            abort(500)
+            # no matching chart block was found
+            return None
 
         return next_block
 

--- a/comport/templates/department/site/assaults.html
+++ b/comport/templates/department/site/assaults.html
@@ -7,7 +7,8 @@
 
     <h2>Assaults on Officers</h2>
 
-    {% if not editing %}
+    <!-- display introduction text -->
+    {% if not editing and chart_blocks['introduction'] %}
     <p class="intro_text">
       {{ markdown(chart_blocks['introduction'].content) }}
     </p>
@@ -25,7 +26,8 @@
 
   </div> <!-- end col -->
 
-  {% if editing %}
+  <!-- edit introduction text -->
+  {% if editing and chart_blocks['introduction'] %}
   <div class="editing-form col-xs-12 col-sm-6">
     <form method="post" action="/content/{{ chart_blocks['introduction'].slug }}/{{department.id}}">
       <div class="form-group">
@@ -38,10 +40,13 @@
   </div>  <!-- end col -->
   {% endif %}
 
+<!-- display/edit first block -->
+{% if chart_blocks['first-block'] %}
 {{ brick(chart_blocks['first-block'], department, editing, one_col=True) }}
-
+{% endif %}
 </div>  <!-- end row -->
 
+<!-- display/edit remaining blocks -->
 {% for block in chart_blocks['blocks'] %}
 <div class="row">
 {{ brick(block, department, editing) }}
@@ -55,7 +60,9 @@
 var csv_url = '{{ url_for("department.assaults_csv", department_id=department.id ) }}';
 var DEMOGRAPHICS = {{ department.serialize_demographics()|safe }};
 var charts = [
+  {% if chart_blocks['first-block'] %}
   "{{chart_blocks['first-block'].slug}}",
+  {% endif %}
   {% for block in chart_blocks['blocks'] -%}
   "{{ block.slug }}",
   {%- endfor %}

--- a/comport/templates/department/site/complaints.html
+++ b/comport/templates/department/site/complaints.html
@@ -7,7 +7,8 @@
 
     <h2>Citizen Complaints</h2>
 
-    {% if not editing %}
+    <!-- display introduction text -->
+    {% if not editing and chart_blocks['introduction'] %}
     <p class="intro_text">
       {{ markdown(chart_blocks['introduction'].content) }}
     </p>
@@ -25,7 +26,8 @@
 
   </div> <!-- end col -->
 
-  {% if editing %}
+  <!-- edit introduction text -->
+  {% if editing and chart_blocks['introduction'] %}
   <div class="editing-form col-xs-12 col-sm-6">
     <form method="post" action="/content/{{ chart_blocks['introduction'].slug }}/{{department.id}}">
       <div class="form-group">
@@ -38,10 +40,13 @@
   </div>  <!-- end col -->
   {% endif %}
 
+<!-- display/edit first block -->
+{% if chart_blocks['first-block'] %}
 {{ brick(chart_blocks['first-block'], department, editing, one_col=True) }}
-
+{% endif %}
 </div>  <!-- end row -->
 
+<!-- display/edit remaining blocks -->
 {% for block in chart_blocks['blocks'] %}
 <div class="row">
 {{ brick(block, department, editing) }}
@@ -55,7 +60,9 @@
 var csv_url = '{{ url_for("department.complaints_csv", department_id=department.id ) }}';
 var DEMOGRAPHICS = {{ department.serialize_demographics()|safe }};
 var charts = [
+  {% if chart_blocks['first-block'] %}
   "{{chart_blocks['first-block'].slug}}",
+  {% endif %}
   {% for block in chart_blocks['blocks'] -%}
   "{{ block.slug }}",
   {%- endfor %}

--- a/comport/templates/department/site/ois.html
+++ b/comport/templates/department/site/ois.html
@@ -7,7 +7,8 @@
   <div class="col-xs-12 col-sm-5">
     <h2>Officer Involved Shootings</h2>
 
-    {% if not editing %}
+    <!-- display introduction text -->
+    {% if not editing and chart_blocks['introduction'] %}
     <p class="intro_text">
       {{ markdown(chart_blocks['introduction'].content) }}
     </p>
@@ -23,10 +24,10 @@
 
     {{ chart_toc(chart_blocks=chart_blocks) }}
 
-  </div>  <!-- end col -->
+  </div> <!-- end col -->
 
-
-  {% if editing %}
+  <!-- edit introduction text -->
+  {% if editing and chart_blocks['introduction'] %}
   <div class="editing-form col-sm-6">
     <form method="post" action="/content/{{ chart_blocks['introduction'].slug }}/{{department.id}}">
       <div class="form-group">
@@ -34,15 +35,18 @@
         <textarea class="form-control" name="chart_content">{{ chart_blocks['introduction'].content }}</textarea>
         <input type="hidden" name="chart_title" value=""/>
       </div>
-        <input type="submit" />
-     </form>
+      <input type="submit" />
+    </form>
   </div>  <!-- end col -->
   {% endif %}
 
+<!-- display/edit first block -->
+{% if chart_blocks['first-block'] %}
 {{ brick(chart_blocks['first-block'], department, editing, one_col=True) }}
-
+{% endif %}
 </div>  <!-- end row -->
 
+<!-- display/edit remaining blocks -->
 {% for block in chart_blocks['blocks'] %}
 <div class="row">
 {{ brick(block, department, editing) }}
@@ -56,7 +60,9 @@
 var csv_url = '{{ url_for("department.ois_csv", department_id=department.id ) }}';
 var DEMOGRAPHICS = {{ department.serialize_demographics()|safe }};
 var charts = [
+  {% if chart_blocks['first-block'] %}
   "{{chart_blocks['first-block'].slug}}",
+  {% endif %}
   {% for block in chart_blocks['blocks'] -%}
   "{{ block.slug }}",
   {%- endfor %}

--- a/comport/templates/department/site/useofforce.html
+++ b/comport/templates/department/site/useofforce.html
@@ -3,17 +3,18 @@
 {% block dataset_content %}
 
 <div class="row">
-
   <div class="col-xs-12 col-sm-5">
   
     <h2>Use of Force</h2>
 
-    {% if not editing %}
+    <!-- display introduction text -->
+    {% if not editing and chart_blocks['introduction'] %}
     <p class="intro_text">
       {{ markdown(chart_blocks['introduction'].content) }}
     </p>
     {% endif %}
 
+    <!-- data button -->
     <a href="{{ url_for(
       'department.public_uof_schema', short_name=department.short_name.upper())
       }}" class="btn btn-primary btn-lg">
@@ -25,8 +26,8 @@
 
   </div>  <!-- end col -->
 
-
-  {% if editing %}
+  <!-- edit introduction text -->
+  {% if editing and chart_blocks['introduction'] %}
   <div class="editing-form col-xs-12 col-lg-6">
     <form method="post" action="/content/{{ chart_blocks['introduction'].slug }}/{{department.id}}">
       <div class="form-group">
@@ -34,16 +35,18 @@
         <textarea class="form-control" name="chart_content">{{ chart_blocks['introduction'].content }}</textarea>
         <input type="hidden" name="chart_title" value=""/>
       </div>
-        <input type="submit" />
-     </form>
+      <input type="submit" />
+    </form>
   </div>  <!-- end col -->
   {% endif %}
 
+<!-- display/edit first block -->
+{% if chart_blocks['first-block'] %}
 {{ brick(chart_blocks['first-block'], department, editing, one_col=True) }}
-
+{% endif %}
 </div>  <!-- end row -->
 
-
+<!-- display/edit remaining blocks -->
 {% for block in chart_blocks['blocks'] %}
 <div class="row">
 {{ brick(block, department, editing) }}
@@ -57,7 +60,9 @@
 var csv_url = '{{ url_for("department.use_of_force_csv", department_id=department.id ) }}';
 var DEMOGRAPHICS = {{ department.serialize_demographics()|safe }};
 var charts = [
+  {% if chart_blocks['first-block'] %}
   "{{chart_blocks['first-block'].slug}}",
+  {% endif %}
   {% for block in chart_blocks['blocks'] -%}
   "{{ block.slug }}",
   {%- endfor %}

--- a/tests/test_admin_forms.py
+++ b/tests/test_admin_forms.py
@@ -51,7 +51,7 @@ class TestNewDepartmentForm:
         assert 'The department short name "{}" is already registered.'.format(test_short_name) in form.department_short_name.errors
 
 
-@pytest.mark.usefixtures('app')
+@pytest.mark.usefixtures('db')
 class TestStartExtractorForm:
 
     def test_can_set_extractor_start_date(self, testapp):

--- a/tests/test_admin_forms.py
+++ b/tests/test_admin_forms.py
@@ -58,7 +58,7 @@ class TestStartExtractorForm:
         ''' Can set an extraction start date.
         '''
         # set up the department
-        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=False)
 
         # set up a user
         user = User.create(username="moby", email="moby@example.com", password="password")

--- a/tests/test_extractor_api.py
+++ b/tests/test_extractor_api.py
@@ -37,7 +37,7 @@ class TestHeartbeat:
         ''' Send a valid heartbeat post, get a valid response.
         '''
         # set up the extractor
-        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=False)
         Extractor.create(username='extractor', email='extractor@example.com', password="password", department_id=department.id, next_month=10, next_year=2006)
 
         # set the correct authorization
@@ -54,7 +54,7 @@ class TestHeartbeat:
     def test_current_mmyy_on_no_setdate(self, testapp):
         ''' When there is no fixed date, it should send the current month and current year '''
         # set up the extractor
-        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=False)
         Extractor.create(username='extractor', email='extractor@example.com', password="password", department_id=department.id)
 
         # set the correct authorization
@@ -78,7 +78,7 @@ class TestHeartbeat:
         ''' A valid heartbeat post triggers a Slack notification
         '''
         # set up the extractor
-        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=False)
         Extractor.create(username='extractor', email='extractor@example.com', password="password", department_id=department.id, next_month=10, next_year=2006)
 
         # set the correct authorization

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -281,14 +281,6 @@ class TestPagesRespond:
 
         assert response.status_code == 200
 
-    def test_loading_unconfigured_data_type_redirects_to_index(self, testapp):
-        # create a department
-        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=False)
-
-        # make a request to a non-public front page
-        redirect_response = testapp.get("/department/{}/assaultsonofficers/".format(department.short_name), status=500)
-        assert redirect_response.status_code == 500
-
     def test_assaults_front_page_exists(self, testapp):
         # get a department and intro block from the fixture
         department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=True)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -18,12 +18,12 @@ class TestConditionalAccess:
 
     def test_department_is_public_by_default(self):
         # create a department
-        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=False)
         assert department.is_public
 
     def test_department_can_be_set_private(self):
         # create a department
-        department = Department.create(name="Good Police Department", short_name="GPD", is_public=False, load_defaults=False)
+        department = Department.create(name="IM Police Department", short_name="IMPD", is_public=False, load_defaults=False)
         assert not department.is_public
 
     def test_department_not_logged_in_unauthorized(self, testapp):
@@ -73,7 +73,7 @@ class TestConditionalAccess:
 
     def test_datset_is_public_by_default(self):
         # create a department
-        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=False)
         assert hasattr(department, "is_public_assaults_on_officers")
         assert hasattr(department, "is_public_officer_involved_shootings")
         assert hasattr(department, "is_public_citizen_complaints")
@@ -168,7 +168,7 @@ class TestConditionalAccess:
 
     def test_only_department_user_can_access_non_public_datasets(self, testapp):
         # create a department
-        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=True)
+        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=True)
         department.is_public_citizen_complaints = False
         department.is_public_use_of_force_incidents = False
         department.is_public_officer_involved_shootings = False
@@ -283,7 +283,7 @@ class TestPagesRespond:
 
     def test_loading_unconfigured_data_type_redirects_to_index(self, testapp):
         # create a department
-        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=False)
+        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=False)
 
         # make a request to a non-public front page
         redirect_response = testapp.get("/department/{}/assaultsonofficers/".format(department.short_name), status=500)
@@ -291,7 +291,7 @@ class TestPagesRespond:
 
     def test_assaults_front_page_exists(self, testapp):
         # get a department and intro block from the fixture
-        department = Department.create(name="Good Police Department", short_name="GPD", load_defaults=True)
+        department = Department.create(name="IM Police Department", short_name="IMPD", load_defaults=True)
 
         # make a request to specific front page
         response = testapp.get("/department/{}/assaultsonofficers/".format(department.short_name))


### PR DESCRIPTION
No longer throws a 500 when encountering missing chart blocks.

Closes #141 