### PR TITLE
Redirect to dataset pages

### DIFF
--- a/comport/department/models.py
+++ b/comport/department/models.py
@@ -193,6 +193,29 @@ class Department(SurrogatePK, Model):
     def __repr__(self):
         return '<Department({name})>'.format(name=self.name)
 
+    def get_first_dataset_path(self):
+        ''' Return a string representing the path to the first existing dataset page for this department.
+            For use in url_for calls.
+        '''
+        lookup = [
+            {"prefix": "CitizenComplaint", "path": "department.public_complaints"},
+            {"prefix": "UseOfForceIncident", "path": "department.public_uof"},
+            {"prefix": "OfficerInvolvedShooting", "path": "department.public_ois"},
+            {"prefix": "AssaultOnOfficer", "path": "department.public_assaults"}
+        ]
+
+        for check in lookup:
+            # if there's a class for this dataset, return its path
+            try:
+                getattr(importlib.import_module("comport.data.models"), "{}{}".format(check["prefix"], self.short_name))
+            except AttributeError:
+                continue
+            else:
+                return check["path"]
+
+        # no dataset classes were found
+        return None
+
     def get_uof_csv(self):
         output = io.StringIO()
 

--- a/comport/department/views.py
+++ b/comport/department/views.py
@@ -413,14 +413,6 @@ def public_uof(short_name):
         abort(404)
     return render_template("department/site/useofforce.html", department=department, chart_blocks=department.get_uof_blocks(), editing=False, published=True)
 
-@blueprint.route("/<short_name>/officerinvolvedshootings/")
-@authorized_access_only(dataset="officer_involved_shootings")
-def public_ois(short_name):
-    department = Department.query.filter_by(short_name=short_name.upper()).first()
-    if not department:
-        abort(404)
-    return render_template("department/site/ois.html", department=department, chart_blocks=department.get_ois_blocks(), editing=False, published=True)
-
 @blueprint.route('/<short_name>/schema/useofforce/')
 @authorized_access_only(dataset="use_of_force_incidents")
 def public_uof_schema(short_name):
@@ -428,6 +420,14 @@ def public_uof_schema(short_name):
     if not department:
         abort(404)
     return render_template("department/site/schema/useofforce.html", department=department, chart_blocks=department.get_uof_schema_blocks(), editing=False, published=True)
+
+@blueprint.route("/<short_name>/officerinvolvedshootings/")
+@authorized_access_only(dataset="officer_involved_shootings")
+def public_ois(short_name):
+    department = Department.query.filter_by(short_name=short_name.upper()).first()
+    if not department:
+        abort(404)
+    return render_template("department/site/ois.html", department=department, chart_blocks=department.get_ois_blocks(), editing=False, published=True)
 
 @blueprint.route('/<short_name>/schema/officerinvolvedshootings/')
 @authorized_access_only(dataset="officer_involved_shootings")

--- a/comport/public/views.py
+++ b/comport/public/views.py
@@ -38,7 +38,13 @@ def login():
                 if request.args.get("next"):
                     return redirect(request.args.get("next"))
                 if form.user.first_department():
-                    return redirect(url_for("department.department_dashboard", department_id=form.user.first_department().id))
+                    # direct the user to the first existing dataset page
+                    redirect_path = form.user.first_department().get_first_dataset_path()
+                    if redirect_path:
+                        return redirect(url_for(redirect_path, short_name=form.user.first_department().short_name))
+                    else:
+                        flash("There are no datasets configured for this department.", 'alert alert-danger')
+                        return redirect(url_for('public.home'))
                 else:
                     flash("You are not registered in any department. Please contact support.", 'alert alert-danger')
                     return render_template("public/login.html", form=form, published=True)


### PR DESCRIPTION
When a non-admin user logs in, they're directed to the first existing dataset page for their associated department, instead of that department's admin page.

Closes #143 
